### PR TITLE
Snakefile: add warmup job to avoid parallel gdml downloads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -21,6 +21,21 @@ include: "benchmarks/backgrounds/Snakefile"
 include: "benchmarks/barrel_ecal/Snakefile"
 include: "benchmarks/ecal_gaps/Snakefile"
 
+
+rule warmup_run:
+    output:
+        "warmup/{DETECTOR_CONFIG}.edm4hep.root",
+    message: "Ensuring that calibrations/fieldmaps are available for {wildcards.DETECTOR_CONFIG}"
+    shell: """
+ddsim \
+  --runType batch \
+  --numberOfEvents 1 \
+  --compactFile "$DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml" \
+  --outputFile "{output}" \
+  --enableGun
+"""
+
+
 rule matplotlibrc:
     output:
         ".matplotlibrc",

--- a/benchmarks/backgrounds/Snakefile
+++ b/benchmarks/backgrounds/Snakefile
@@ -34,7 +34,8 @@ rule backgrounds_get_DIS:
 
 rule backgrounds_sim:
     input:
-        "input/backgrounds/{NAME}.hepmc",
+        hepmc="input/backgrounds/{NAME}.hepmc",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/{DETECTOR_CONFIG}/backgrounds/{NAME}.edm4hep.root",
     log:
@@ -50,7 +51,7 @@ ddsim \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
   --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles {input} \
+  --inputFiles {input.hepmc} \
   --outputFile {output}
 """
 

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -4,6 +4,7 @@ import os
 rule ecal_gaps_sim:
     input:
         steering_file=provider.remote(remote_path("EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer")),
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
     log:


### PR DESCRIPTION
This is needed to facilitate running benchmarks where downloads may happen.

https://github.com/eic/epic/pull/588
fails in
https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/2627824

This is similar to https://github.com/eic/physics_benchmarks/pull/5

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
