### PR TITLE
Fix ecal_gaps benchmark

### DIFF
--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -73,7 +73,7 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/45to135deg/{particle}_{energy}_45to135deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/130to177deg/{particle}_{energy}_130to177deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         ,
-        filter_name=filter_name, open_files=False, steps_per_file=1, recursive=True,
+        filter_name=filter_name, open_files=False, steps_per_file=1,
     )
 
     print(events.fields)

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -76,8 +76,6 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         filter_name=filter_name, open_files=False, steps_per_file=1,
     )
 
-    print(events.fields)
-
     pt = np.hypot(events["MCParticles.momentum.x"][:,0], events["MCParticles.momentum.y"][:,0])
     theta = np.arctan2(pt, events["MCParticles.momentum.z"][:,0])
     eta = -np.log(np.tan(theta / 2))

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -76,6 +76,8 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         filter_name=filter_name, open_files=False, steps_per_file=1,
     )
 
+    print(events.fields)
+
     pt = np.hypot(events["MCParticles.momentum.x"][:,0], events["MCParticles.momentum.y"][:,0])
     theta = np.arctan2(pt, events["MCParticles.momentum.z"][:,0])
     eta = -np.log(np.tan(theta / 2))

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -74,6 +74,7 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/130to177deg/{particle}_{energy}_130to177deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         ,
         filter_name=filter_name, open_files=False, steps_per_file=1,
+        ignore_duplicates=True, # workaround a regression from https://github.com/scikit-hep/uproot5/pull/1189
     )
 
     print(events.fields)

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -73,7 +73,7 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/45to135deg/{particle}_{energy}_45to135deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/130to177deg/{particle}_{energy}_130to177deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         ,
-        filter_name=filter_name, open_files=False, steps_per_file=1,
+        filter_name=filter_name, open_files=False, steps_per_file=1, recursive=True,
     )
 
     print(events.fields)

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -74,7 +74,6 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/130to177deg/{particle}_{energy}_130to177deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         ,
         filter_name=filter_name, open_files=False, steps_per_file=1,
-        ignore_duplicates=True, # workaround a regression from https://github.com/scikit-hep/uproot5/pull/1189
     )
 
     print(events.fields)

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -74,7 +74,7 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/130to177deg/{particle}_{energy}_130to177deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         ,
         filter_name=filter_name, open_files=False, steps_per_file=1,
-        ignore_duplicates=True, # workaround a regression from https://github.com/scikit-hep/uproot5/pull/1189
+        ignore_duplicates=False, # workaround a regression from https://github.com/scikit-hep/uproot5/pull/1189
     )
 
     print(events.fields)

--- a/benchmarks/ecal_gaps/ecal_gaps.org
+++ b/benchmarks/ecal_gaps/ecal_gaps.org
@@ -74,7 +74,7 @@ def get_events(particle="e-", energy="20GeV", num_files=1):
         | {f"sim_output/{DETECTOR_CONFIG}/{particle}/{energy}/130to177deg/{particle}_{energy}_130to177deg.{INDEX:04d}.eicrecon.tree.edm4eic.root": "events" for INDEX in range(num_files)}
         ,
         filter_name=filter_name, open_files=False, steps_per_file=1,
-        ignore_duplicates=False, # workaround a regression from https://github.com/scikit-hep/uproot5/pull/1189
+        ignore_duplicates=True, # workaround a regression from https://github.com/scikit-hep/uproot5/pull/1189
     )
 
     print(events.fields)

--- a/benchmarks/ecal_gaps/requirements.txt
+++ b/benchmarks/ecal_gaps/requirements.txt
@@ -4,4 +4,4 @@ dask_awkward
 dask_histogram
 distributed >= 2023
 pyhepmc
-uproot >= 5.2.0
+uproot ~= 5.2.0

--- a/benchmarks/ecal_gaps/requirements.txt
+++ b/benchmarks/ecal_gaps/requirements.txt
@@ -4,4 +4,4 @@ dask_awkward
 dask_histogram
 distributed >= 2023
 pyhepmc
-uproot ~= 5.2.0
+uproot >= 5.2.0


### PR DESCRIPTION
Fix for failure
https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/2899956#L369

```output
awkward.errors.FieldNotFoundError: no field 'MCParticles.momentum.x' in record with 7 fields
This error occurred while attempting to slice
    <Array-typetracer [...] type='## * {EcalBarrelImagingRecHits: {"EcalBar...'>
with
    'MCParticles.momentum.x'
```