### PR TITLE
drop use of Snakemake 7.x-specific remote functionality

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,26 +1,15 @@
-configfile: "config.yaml"
-
-if config["remote"] == "S3":
-    from snakemake.remote.S3 import RemoteProvider as S3RemoteProvider
-    provider = S3RemoteProvider(
-        endpoint_url="https://eics3.sdcc.bnl.gov:9000",
-        access_key_id=os.environ["S3_ACCESS_KEY"],
-        secret_access_key=os.environ["S3_SECRET_KEY"],
-    )
-    remote_path = lambda path: f"eictest/{path}"
-elif config["remote"] == "XRootD":
-    from snakemake.remote.XRootD import RemoteProvider as XRootDRemoteProvider
-    provider = XRootDRemoteProvider(
-        stay_on_remote=False,
-    )
-    remote_path = lambda path: f"root://dtn-eic.jlab.org//work/eic2/{path}"
-else:
-    raise ValueError(f"Unexpected config[\"remote\"] = {config['remote']}")
-
 include: "benchmarks/backgrounds/Snakefile"
 include: "benchmarks/barrel_ecal/Snakefile"
 include: "benchmarks/ecal_gaps/Snakefile"
 include: "benchmarks/material_scan/Snakefile"
+
+
+rule fetch_epic:
+    output:
+        filepath="EPIC/{PATH}"
+    shell: """
+xrdcp root://dtn-eic.jlab.org//work/eic2/{output.filepath} {output.filepath}
+"""
 
 
 rule warmup_run:

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -3,7 +3,7 @@ import os
 
 rule ecal_gaps_sim:
     input:
-        "EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
+        steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -3,7 +3,7 @@ import os
 
 rule ecal_gaps_sim:
     input:
-        steering_file=provider.remote(remote_path("EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer")),
+        "EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",

--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,0 @@
-remote: S3


### PR DESCRIPTION
We are looking to migrate to Snakemake where remote store has a different incompatible syntax, and also broken. This PR brings repository into a state when that functionality is not relied up, so the transition can be done smoothly.