### PR TITLE
tracking_performances: fix for removed 7.x-specific remote

### DIFF
--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -1,6 +1,6 @@
 rule tracking_performance_sim:
     input:
-        steering_file=provider.remote(remote_path("EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer")),
+        steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",


### PR DESCRIPTION
Fixes a regression from crossed merges of
https://github.com/eic/detector_benchmarks/pull/29
https://github.com/eic/detector_benchmarks/pull/30