### PR TITLE
mirror.yaml: mirror branch delete actions to eicweb

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,6 +1,7 @@
 name: Mirror and Trigger EICweb
 
 on:
+  delete:
   push:
   workflow_dispatch:
 
@@ -29,6 +30,7 @@ jobs:
         ciskip: true
     - name: Trigger EICweb
       uses: eic/trigger-gitlab-ci@v3
+      if: ${{ github.event_name != 'delete' }}
       with:
         url: https://eicweb.phy.anl.gov
         project_id: 399


### PR DESCRIPTION
Currently, one has to manually remove branches on both repositories. This should take care of propagating the github deletions.