### PR TITLE
tracking_performance: enable running over campaigns

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,9 @@ get_data:
     - mkdir "${DETECTOR_CONFIG}"
     - ln -s "${LOCAL_DATA_PATH}/sim_output" "${DETECTOR_CONFIG}/sim_output"
     - ln -s "../results" "${DETECTOR_CONFIG}/results"
+    # cache downloaded artifacts
+    - if [ -d /scratch ]; then mkdir -p /scratch/EPIC; ln -sf /scratch/EPIC ./EPIC; fi
+    - du -hs /scratch/EPIC
     - ls -lrtha
   retry:
     max: 2

--- a/benchmarks/tracking_performances/README.md
+++ b/benchmarks/tracking_performances/README.md
@@ -1,6 +1,10 @@
 Shyam Kumar; INFN Bari, Italy; shyam055119@gmail.com
 Method to produce the tracking performances with ePIC tracker
 The scripts can be used to create the debug plots for the momentum resolutions.
-In the first step enter inside eic-shell and create a directory (your preferred name) there and put all the script inside that.
-Simply run the command source Script_widebin.sh
+
+To run a full simulation-reconstruction-analysis chain do:
+```
+snakemake --cores 1 tracking_performance
+```
+
 It will produce the results with truth/realistic seeding.

--- a/benchmarks/tracking_performances/README.md
+++ b/benchmarks/tracking_performances/README.md
@@ -4,7 +4,16 @@ The scripts can be used to create the debug plots for the momentum resolutions.
 
 To run a full simulation-reconstruction-analysis chain do:
 ```
-snakemake --cores 1 tracking_performance
+snakemake -c2 results/tracking_performances/local
+```
+or, referencing it by the rule name:
+```
+snakemake --cores 1 tracking_performance_local
+```
+
+To process an individual campaign do:
+```
+snakemake -c2 results/tracking_performances/24.04.0
 ```
 
 It will produce the results with truth/realistic seeding.

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -48,27 +48,26 @@ rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
         # TODO pass as a file list?
-        sim=lambda wildcards: branch(
-          wildcards.CAMPAIGN == "local",
-          then=expand(
+        sim=lambda wildcards:
+          expand(
               "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
               DETECTOR_CONFIG="epic_craterlake_tracking_only",
               ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
               PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
               INDEX=range(1),
-          ),
-          otherwise=expand(
+          )
+          if wildcards.CAMPAIGN == "local" else
+          expand(
               "EPIC/RECO/{{CAMPAIGN}}/epic_craterlake/SINGLE/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
               DETECTOR_CONFIG="epic_craterlake",
               ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
               PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
               INDEX=range(1),
           ),
-        ),
     output:
-        "{SEEDING}/pi-/mom/Performances_mom_{MOMENTUM}_mom_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
-        "{SEEDING}/pi-/dca/Performances_dca_{MOMENTUM}_dca_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
-        combined_root=temp("sim_{SEEDING}_{MOMENTUM}_{SEEDING_IGNORE}_{PARTICLE}.root"),
+        "{CAMPAIGN}/{SEEDING}/pi-/mom/Performances_mom_{MOMENTUM}_mom_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
+        "{CAMPAIGN}/{SEEDING}/pi-/dca/Performances_dca_{MOMENTUM}_dca_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
+        combined_root=temp("{CAMPAIGN}/sim_{SEEDING}_{MOMENTUM}_{SEEDING_IGNORE}_{PARTICLE}.root"),
     shell:
         """
 if [[ "{wildcards.SEEDING}" == "truthseed" ]]; then
@@ -77,7 +76,8 @@ elif [[ "{wildcards.SEEDING}" == "realseed" ]]; then
         SEEDING="Seeded"
 fi
 hadd {output.combined_root} {input.sim}
-root -l -b -q {input.script}'("{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, "'$SEEDING'")'
+cd {wildcards.CAMPAIGN}
+root -l -b -q ../{input.script}'("../{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, "'$SEEDING'")'
 """
 
 
@@ -85,25 +85,26 @@ rule tracking_performance_summary_at_eta:
     input:
         expand(
             [
-                "truthseed/pi-/mom/Performances_mom_{MOMENTUM:.1f}_mom_resol_truth_pi-.root",
-                "truthseed/pi-/dca/Performances_dca_{MOMENTUM:.1f}_dca_resol_truth_pi-.root",
-                "realseed/pi-/mom/Performances_mom_{MOMENTUM:.1f}_mom_resol_realseed_pi-.root",
-                "realseed/pi-/dca/Performances_dca_{MOMENTUM:.1f}_dca_resol_realseed_pi-.root",
+                "{{CAMPAIGN}}/truthseed/pi-/mom/Performances_mom_{MOMENTUM:.1f}_mom_resol_truth_pi-.root",
+                "{{CAMPAIGN}}/truthseed/pi-/dca/Performances_dca_{MOMENTUM:.1f}_dca_resol_truth_pi-.root",
+                "{{CAMPAIGN}}/realseed/pi-/mom/Performances_mom_{MOMENTUM:.1f}_mom_resol_realseed_pi-.root",
+                "{{CAMPAIGN}}/realseed/pi-/dca/Performances_dca_{MOMENTUM:.1f}_dca_resol_realseed_pi-.root",
             ],
             MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 20.0],
         ),
         script="benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C",
     output:
         expand(
-            "Debug_Plots/{SEEDING}/pi-/mom/{SEEDING}_mom_resol_mom{MOMENTUM:.1f}_{{ETA_MIN}}_eta_{{ETA_MAX}}.png",
+            "{{CAMPAIGN}}/Debug_Plots/{SEEDING}/pi-/mom/{SEEDING}_mom_resol_mom{MOMENTUM:.1f}_{{ETA_MIN}}_eta_{{ETA_MAX}}.png",
             SEEDING=["real", "truth"],
             MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 20.0],
         ),
-        "Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.png",
-        "Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.root",
+        "{CAMPAIGN}/Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.png",
+        "{CAMPAIGN}/Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.root",
     shell:
         """
-root -l -b -q {input.script}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1.)'
+cd {wildcards.CAMPAIGN}
+root -l -b -q ../{input.script}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1.)'
 """
 
 
@@ -113,15 +114,34 @@ rule tracking_performance:
     input:
         expand(
             [
-                "Final_Results/pi-/mom/mom_resol_{ETA_BIN}.png",
-                "Final_Results/pi-/mom/mom_resol_{ETA_BIN}.root",
+                "{{CAMPAIGN}}/Final_Results/pi-/mom/mom_resol_{ETA_BIN}.png",
+                "{{CAMPAIGN}}/Final_Results/pi-/mom/mom_resol_{ETA_BIN}.root",
             ],
             ETA_BIN=[f"{eta_min:.1f}_eta_{eta_max:.1f}" for eta_min, eta_max in zip(TRACKING_PERFORMANCE_ETA_BINS[:-1], TRACKING_PERFORMANCE_ETA_BINS[1:])],
         ),
     output:
-        directory("results/tracking_performances")
+        directory("results/tracking_performances/{CAMPAIGN}/")
     shell:
         """
 mkdir {output}
 cp {input} {output}
 """
+
+
+rule tracking_performance_local:
+    input:
+        "results/tracking_performances/local",
+
+
+rule tracking_performance_campaigns:
+    input:
+        expand(
+            "results/tracking_performances/{CAMPAIGN}",
+            CAMPAIGN=[
+                "23.10.0",
+                "23.11.0",
+                "23.12.0",
+                "24.03.1",
+                "24.04.0",
+            ],
+        )

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -103,14 +103,22 @@ rule tracking_performance_summary_at_eta:
         "{CAMPAIGN}/Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.root",
     shell:
         """
-set +e
-EPIC_VERSION="$(echo $DETECTOR_PATH | sed -n -e 's/.*epic-\([^-]\+\).*/\\1/p')"
-EICRECON_VERSION="$(eicrecon -v | sed -n -e 's/.*\(v[0-9.]\+\).*/\\1/p')"
-set -e
-echo "ePIC version: $EPIC_VERSION"
-echo "EICrecon version: $EICRECON_VERSION"
+if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
+	set +e
+	EPIC_VERSION="${{DETECTOR_VERSION:-}}"
+	EICRECON_VERSION="$(eicrecon -v | sed -n -e 's/.*\(v[0-9\.]\+\).*/\\1/p')"
+	# Legacy detection
+	: ${{EPIC_VERSION:="$(echo $DETECTOR_PATH | sed -n -e 's/.*epic-\([^-/]\+\).*/\\1/p')"}}
+	set -e
+
+	echo "ePIC version: $EPIC_VERSION"
+	echo "EICrecon version: $EICRECON_VERSION"
+	EXTRA_LEGEND="ePIC $EPIC_VERSION / EICrecon $EICRECON_VERSION"
+else
+	EXTRA_LEGEND="ePIC Simulation {wildcards.CAMPAIGN}"
+fi
 cd {wildcards.CAMPAIGN}
-root -l -b -q ../{input.script}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1., true, "'$EPIC_VERSION'", "'$EICRECON_VERSION'")'
+root -l -b -q ../{input.script}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1., true, "'"$EXTRA_LEGEND"'")'
 """
 
 

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -48,12 +48,22 @@ rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
         # TODO pass as a file list?
-        sim=lambda wildcards: expand(
-            "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
-            DETECTOR_CONFIG="epic_craterlake_tracking_only",
-            ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
-            PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
-            INDEX=range(1),
+        sim=lambda wildcards: branch(
+          wildcards.CAMPAIGN == "local",
+          then=expand(
+              "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
+              DETECTOR_CONFIG="epic_craterlake_tracking_only",
+              ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
+              PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
+              INDEX=range(1),
+          ),
+          otherwise=expand(
+              "EPIC/RECO/{{CAMPAIGN}}/epic_craterlake/SINGLE/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
+              DETECTOR_CONFIG="epic_craterlake",
+              ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
+              PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
+              INDEX=range(1),
+          ),
         ),
     output:
         "{SEEDING}/pi-/mom/Performances_mom_{MOMENTUM}_mom_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
@@ -80,14 +90,14 @@ rule tracking_performance_summary_at_eta:
                 "realseed/pi-/mom/Performances_mom_{MOMENTUM:.1f}_mom_resol_realseed_pi-.root",
                 "realseed/pi-/dca/Performances_dca_{MOMENTUM:.1f}_dca_resol_realseed_pi-.root",
             ],
-            MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 15.0],
+            MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 20.0],
         ),
         script="benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C",
     output:
         expand(
             "Debug_Plots/{SEEDING}/pi-/mom/{SEEDING}_mom_resol_mom{MOMENTUM:.1f}_{{ETA_MIN}}_eta_{{ETA_MAX}}.png",
             SEEDING=["real", "truth"],
-            MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 15.0],
+            MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 20.0],
         ),
         "Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.png",
         "Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.root",

--- a/benchmarks/tracking_performances/Tracking_Performances.C
+++ b/benchmarks/tracking_performances/Tracking_Performances.C
@@ -82,7 +82,7 @@ void Tracking_Performances(TString filename="tracking_output",TString particle="
       
       if (fabs(ptmc) < pTcut) continue;
 
-      Double_t pmc = charge[j]*sqrt(px_mc[j]*px_mc[j]+py_mc[j]*py_mc[j]+pz_mc[j]*pz_mc[j]); 
+      Double_t pmc = (1./charge[j])*sqrt(px_mc[j]*px_mc[j]+py_mc[j]*py_mc[j]+pz_mc[j]*pz_mc[j]); // 1./(q/p); similar to prec
       Double_t prec = 1./qoverp[j]; 
 
       Double_t pzrec = prec*TMath::Cos(theta[j]);  Double_t pt_rec = sqrt(prec*prec-pzrec*pzrec);  

--- a/benchmarks/tracking_performances/Tracking_Performances.C
+++ b/benchmarks/tracking_performances/Tracking_Performances.C
@@ -34,11 +34,11 @@ void Tracking_Performances(TString filename="tracking_output",TString particle="
    int theta_val[nbins_eta+1] ={3,50,45,135,130,177};
    int nfiles = 100; 
    double eta[nbins_eta+1]={-3.5,-2.5,-1.0,1.0,2.5,3.5};
-   double pt[nbins_eta+1]={0.1,0.5,1.0,2.0,5.0,10.0};
+   double pt[nbins_eta+1]={0.5,1.0,2.0,5.0,10.0,20.1};
    TH1D *histp[nbins_eta]; 
    
-    TH3D *h_d0xy_3d= new TH3D("h_d0xy_3d","Transverse Pointing Resolution",500,-0.1,0.1,70,-3.5,3.5,200,0.,20.);
-    TH3D *h_d0z_3d= new TH3D("h_d0z_3d","Longitudinal Pointing Resolution",500,-0.1,0.1,70,-3.5,3.5,200,0.,20.);
+    TH3D *h_d0xy_3d= new TH3D("h_d0xy_3d","Transverse Pointing Resolution",500,-0.1,0.1,70,-3.5,3.5,201,0.,20.1);
+    TH3D *h_d0z_3d= new TH3D("h_d0z_3d","Longitudinal Pointing Resolution",500,-0.1,0.1,70,-3.5,3.5,201,0.,20.1);
    
    for (int i=0; i<nbins_eta; i++){
    histp[i] = new TH1D(Form("hist_etabin%d",i),Form("hist_etabin%d",i),600,-0.3,0.3);

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -18,12 +18,27 @@ bench:tracking_performance:
   needs:
     - ["sim:tracking_performance"]
   script:
-    - snakemake --cores 1 tracking_performance
+    - snakemake --cores 1 tracking_performance_local
 
 collect_results:tracking_performance:
   extends: .det_benchmark
   stage: collect
   needs:
     - "bench:tracking_performance"
+  script:
+    - ls -lrht
+
+bench:tracking_performance_campaigns:
+  extends: .det_benchmark
+  stage: benchmarks
+  #when: manual
+  script:
+    - snakemake --cores 1 tracking_performance_campaigns
+
+collect_results:tracking_performance_campaigns:
+  extends: .det_benchmark
+  stage: collect
+  needs:
+    - "bench:tracking_performance_campaigns"
   script:
     - ls -lrht

--- a/benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C
+++ b/benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C
@@ -151,7 +151,7 @@ void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1
 	mgMom->Add(gr2);
 	c_mom->cd();
 	mgMom->GetXaxis()->SetRangeUser(0.40,20.2);
-	mgMom->GetYaxis()->SetRangeUser(0.,10.0);
+	mgMom->GetYaxis()->SetRangeUser(0.0,1.50*TMath::MaxElement(gr2->GetN(),gr2->GetY())); // 50% more of the maximum value on yaxis
 	mgMom->Draw("AP");
 	lmom->AddEntry(gr1,"Truth Seeding");
 	lmom->AddEntry(gr2,"Realistic Seeding");

--- a/benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C
+++ b/benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C
@@ -10,7 +10,7 @@
 #define mpi 0.139  // 1.864 GeV/c^2
 
 void draw_req_Mom(double etamin, double etamax, double xmin=0., double xmax=0.);
-void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, double range =0.3, Bool_t drawreq=1, TString epic ="", TString eicrecon = "") // name = p, pt for getting p or pt dependence fitted results
+void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, double range =0.3, Bool_t drawreq=1, TString extra_legend = "") // name = p, pt for getting p or pt dependence fitted results
 {
 
 //=== style of the plot=========
@@ -52,7 +52,8 @@ void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1
   lmom = new TLegend(0.65,0.80,0.90,0.93);
   lmom->SetTextSize(0.03);
   lmom->SetBorderSize(0);
-  lmom->SetHeader(Form("%s ePIC(%s/%s): %1.1f < #eta < %1.1f",symbolname.Data(),epic.Data(),eicrecon.Data(),etamin,etamax),"C");
+  lmom->SetHeader(extra_legend.Data(), "C");
+  lmom->AddEntry((TObject*)0, Form("%s, %1.1f < #eta < %1.1f", symbolname.Data(), etamin, etamax), "C");
   
   TF1 *func_truth = new TF1("func_truth","gaus",-0.5,0.5);
   TF1 *func_real = new TF1("func_real","gaus",-0.5,0.5);
@@ -165,7 +166,7 @@ void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1
 	c_mom->SaveAs(Form("Final_Results/%s/mom/mom_resol_%1.1f_eta_%1.1f.png",particle.Data(),etamin,etamax));
 	
 	// Write the numbers in output file for comparisons
-	outfile<<"ePIC"<<setw(20)<<epic.Data()<<setw(20)<<"EICrecon"<<setw(20)<<eicrecon.Data()<<endl;
+	outfile << extra_legend << endl;
   outfile<<"Etamin"<<setw(20)<<"Etamax"<<setw(20)<<"p (GeV/c) \t"<<setw(20)<<"Resol  #mum (Truth)"<<setw(20)<<"Resol #mum (Real)"<<endl;
   for (Int_t i = 0; i<gr1->GetN(); ++i){
   double x,ytrue, yreal;

--- a/benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C
+++ b/benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C
@@ -24,7 +24,7 @@ void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1
    gStyle->SetOptStat(1);
   
    const Int_t nfiles = 6;
-   double mom[nfiles] ={0.5,1.0,2.0,5.0,10.0,15.0};
+   double mom[nfiles] ={0.5,1.0,2.0,5.0,10.0,20.0};
    std::vector<double> momV_truth, momV_real, momresolV_truth, err_momresolV_truth, momresolV_real, err_momresolV_real;
    momV_truth.clear(); momV_real.clear(); momresolV_truth.clear(); err_momresolV_truth.clear(); momresolV_real.clear(); err_momresolV_real.clear();
    
@@ -150,7 +150,7 @@ void doCompare_truth_real_widebins_mom(TString particle = "pi-",double etamin=-1
 	mgMom->Add(gr1);
 	mgMom->Add(gr2);
 	c_mom->cd();
-	mgMom->GetXaxis()->SetRangeUser(0.40,15.2);
+	mgMom->GetXaxis()->SetRangeUser(0.40,20.2);
 	mgMom->GetYaxis()->SetRangeUser(0.,10.0);
 	mgMom->Draw("AP");
 	lmom->AddEntry(gr1,"Truth Seeding");


### PR DESCRIPTION
This enables running over campaigns. The 15 GeV point had to be replaced with 20 GeV because that is what is currently available in the productions.

The current strategy is to run over a single file and enable caching of those to scratch on eicweb. We can expand once this is confirmed to be workable.