### PR TITLE
fix: bench:tracking_performance: `snakemake --cores 3`

### DIFF
--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -18,7 +18,7 @@ bench:tracking_performance:
   needs:
     - ["sim:tracking_performance"]
   script:
-    - snakemake --cores 1 tracking_performance_local
+    - snakemake --cores 3 tracking_performance_local
 
 collect_results:tracking_performance:
   extends: .det_benchmark


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR causes bench:tracking_performance to run with 3 cores (simultaneous jobs). This should balance the pipeline better.
![image](https://github.com/user-attachments/assets/a7ceb040-5ad5-43cc-960a-c72efc4acfef)

### What kind of change does this PR introduce?
- [x] Bug fix (issue: bench:tracking_performance takes a long time)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @Simple-Shyam 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.