### PR TITLE
treewide: use `set -m` and exec to avoid lingering ddsim processes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -18,7 +18,8 @@ rule warmup_run:
         "warmup/{DETECTOR_CONFIG}.edm4hep.root",
     message: "Ensuring that calibrations/fieldmaps are available for {wildcards.DETECTOR_CONFIG}"
     shell: """
-ddsim \
+set -m # monitor mode to prevent lingering processes
+exec ddsim \
   --runType batch \
   --numberOfEvents 1 \
   --compactFile "$DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml" \

--- a/benchmarks/backgrounds/Snakefile
+++ b/benchmarks/backgrounds/Snakefile
@@ -13,7 +13,8 @@ rule backgrounds_sim:
         N_EVENTS=100
     shell:
         """
-ddsim \
+set -m # monitor mode to prevent lingering processes
+exec ddsim \
   --runType batch \
   --part.minimalKineticEnergy 100*GeV  \
   --filter.tracker edep0 \
@@ -39,7 +40,7 @@ rule backgrounds_ecal_backwards:
     threads: workflow.cores
     shell:
         """
-set -m # monitor mode to prevent lingering shells
+set -m # monitor mode to prevent lingering processes
 cleanup() {{
   echo Cleaning up
   kill $WORKER_PID $SCHEDULER_PID

--- a/benchmarks/barrel_ecal/Snakefile
+++ b/benchmarks/barrel_ecal/Snakefile
@@ -26,7 +26,8 @@ rule emcal_barrel_particles:
         "{DETECTOR_CONFIG}/sim_output/sim_emcal_barrel_{PARTICLE}_energies{E_MIN}_{E_MAX}.edm4hep.root"
     shell:
         """
-ddsim \
+set -m # monitor mode to prevent lingering processes
+exec ddsim \
    --runType batch \
    -v WARNING \
    --part.minimalKineticEnergy 0.5*GeV  \

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -18,7 +18,8 @@ rule ecal_gaps_sim:
         N_EVENTS=1000
     shell:
         """
-ddsim \
+set -m # monitor mode to prevent lingering processes
+exec ddsim \
   --runType batch \
   --enableGun \
   --steeringFile "{input.steering_file}" \
@@ -41,7 +42,8 @@ rule ecal_gaps_recon:
     wildcard_constraints:
         INDEX="\d{4}",
     shell: """
-env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
+set -m # monitor mode to prevent lingering processes
+exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
   eicrecon {input} -Ppodio:output_file={output} \
   -Ppodio:output_include_collections=EcalEndcapNRecHits,EcalBarrelScFiRecHits,EcalBarrelImagingRecHits,EcalEndcapPRecHits,MCParticles
 """

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -15,7 +15,8 @@ rule tracking_performance_sim:
         N_EVENTS=10000
     shell:
         """
-ddsim \
+set -m # monitor mode to prevent lingering processes
+exec ddsim \
   --runType batch \
   --enableGun \
   --steeringFile "{input.steering_file}" \
@@ -38,7 +39,8 @@ rule tracking_performance_recon:
     wildcard_constraints:
         INDEX="\d{4}",
     shell: """
-env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
+set -m # monitor mode to prevent lingering processes
+exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
   eicrecon {input} -Ppodio:output_file={output} \
   -Ppodio:output_include_collections=MCParticles,CentralCKFTrajectories,CentralCKFTrackParameters,CentralCKFSeededTrackParameters,CentralTrackVertices
 """


### PR DESCRIPTION
Should help to avoid issues like jobs hanging until timeout [1] and processes keeping running after ctrl-c in the interactive running.

[1] https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/3601180