### PR TITLE
snakemake.yml: allow using S3 (XRootD is down sometimes)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,6 +113,7 @@ get_data:
   needs:
     - ["get_data","common:detector"]
   before_script:
+    - mc config host add S3 https://eics3.sdcc.bnl.gov:9000 ${S3_ACCESS_KEY} ${S3_SECRET_KEY}
     - source .local/bin/env.sh
     - ls -lrtha 
     - ln -s "${LOCAL_DATA_PATH}/sim_output" sim_output

--- a/benchmarks/backgrounds/Snakefile
+++ b/benchmarks/backgrounds/Snakefile
@@ -10,7 +10,8 @@ rule backgrounds_sim:
     log:
         "sim_output/{DETECTOR_CONFIG}/backgrounds/{PATH}.edm4hep.root.log",
     params:
-        N_EVENTS=100
+        N_EVENTS=100,
+        hepmc=lambda wildcards: get_remote_path(f"{wildcards.PATH}.hepmc3.tree.root"),
     shell:
         """
 ddsim \
@@ -20,7 +21,7 @@ ddsim \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
   --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles root://dtn-eic.jlab.org//work/eic2/{wildcards.PATH}.hepmc3.tree.root \
+  --inputFiles {params.hepmc} \
   --outputFile {output}
 """
 

--- a/snakemake.yml
+++ b/snakemake.yml
@@ -1,0 +1,1 @@
+remote_provider: XRootD

--- a/snakemake.yml
+++ b/snakemake.yml
@@ -1,1 +1,1 @@
-remote_provider: XRootD
+remote_provider: S3

--- a/snakemake.yml
+++ b/snakemake.yml
@@ -1,1 +1,1 @@
-remote_provider: S3
+remote_provider: XRootD


### PR DESCRIPTION
XRootD had been down for two weekends in a row. It's time to switch back to S3.