### PR TITLE
.gitlab-ci.yml: cleanup disk space on success

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,9 @@ benchmarks:detector:success:
   variables:
     STATE: "success"
     DESCRIPTION: "Succeeded!"
+  after_script:
+    # Cleanup scratch space
+    - rm -rfv $LOCAL_DATA_PATH
   when: on_success
 
 benchmarks:detector:failure:

--- a/benchmarks/backgrounds/config.yml
+++ b/benchmarks/backgrounds/config.yml
@@ -28,3 +28,4 @@ collect_results:backgrounds:
     - "bench:backgrounds_emcal_backwards"
   script:
     - ls -lrht
+    - snakemake --cores 1 --delete-all-output backgrounds_ecal_backwards

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -35,3 +35,4 @@ collect_results:backwards_ecal:
     - "bench:backwards_ecal"
   script:
     - ls -lrht
+    - snakemake --cores 1 --delete-all-output backwards_ecal

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -24,3 +24,4 @@ collect_results:ecal_gaps:
     - "bench:ecal_gaps"
   script:
     - ls -lrht
+    - snakemake --cores 1 --delete-all-output ecal_gaps

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -27,6 +27,7 @@ collect_results:tracking_performance:
     - "bench:tracking_performance"
   script:
     - ls -lrht
+    - snakemake --cores 1 --delete-all-output tracking_performance_local
 
 bench:tracking_performance_campaigns:
   extends: .det_benchmark
@@ -42,3 +43,4 @@ collect_results:tracking_performance_campaigns:
     - "bench:tracking_performance_campaigns"
   script:
     - ls -lrht
+    - snakemake --cores 1 --delete-all-output tracking_performance_campaigns

--- a/benchmarks/zdc_lyso/config.yml
+++ b/benchmarks/zdc_lyso/config.yml
@@ -15,3 +15,4 @@ collect_results:zdc_lyso:
     - "sim:zdc_lyso"
   script:
     - ls -lrht
+    - snakemake --cores 1 --delete-all-output zdc_lyso_local


### PR DESCRIPTION
The failure path for now will not cleanup to allow for restarts. Ideally, the `collect:` jobs could do targeted cleanup using Snakemake.