### PR TITLE
benchmarks/*/config.yml: avoid cleaning up /scratch/EPIC

### DIFF
--- a/benchmarks/backgrounds/config.yml
+++ b/benchmarks/backgrounds/config.yml
@@ -28,4 +28,5 @@ collect_results:backgrounds:
     - "bench:backgrounds_emcal_backwards"
   script:
     - ls -lrht
+    - rm EPIC # remove the symlink to preserve the shared files
     - snakemake --cores 1 --delete-all-output backgrounds_ecal_backwards

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -35,4 +35,5 @@ collect_results:backwards_ecal:
     - "bench:backwards_ecal"
   script:
     - ls -lrht
+    - rm EPIC # remove the symlink to preserve the shared files
     - snakemake --cores 1 --delete-all-output backwards_ecal

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -24,4 +24,5 @@ collect_results:ecal_gaps:
     - "bench:ecal_gaps"
   script:
     - ls -lrht
+    - rm EPIC # remove the symlink to preserve the shared files
     - snakemake --cores 1 --delete-all-output ecal_gaps

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -43,4 +43,5 @@ collect_results:tracking_performance_campaigns:
     - "bench:tracking_performance_campaigns"
   script:
     - ls -lrht
+    - rm EPIC # remove the symlink to preserve the shared files
     - snakemake --cores 1 --delete-all-output tracking_performance_campaigns

--- a/benchmarks/zdc_lyso/config.yml
+++ b/benchmarks/zdc_lyso/config.yml
@@ -15,4 +15,5 @@ collect_results:zdc_lyso:
     - "sim:zdc_lyso"
   script:
     - ls -lrht
+    - rm EPIC # remove the symlink to preserve the shared files
     - snakemake --cores 1 --delete-all-output zdc_lyso_local


### PR DESCRIPTION
### Briefly, what does this PR introduce?

The newly introduced cleanup stage removes too much. E.g.:
```
Deleting EPIC/EVGEN/SINGLE/e-/500MeV/3to50deg/e-_500MeV_3to50deg.steer
```
This should prevent it from doing so.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
Yes