### PR TITLE
Cache fetch_epic using Snakemake's caching facility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,8 +124,6 @@ get_data:
     - ln -s "${LOCAL_DATA_PATH}/sim_output" "${DETECTOR_CONFIG}/sim_output"
     - ln -s "../results" "${DETECTOR_CONFIG}/results"
     # cache downloaded artifacts
-    - if [ -d /scratch ]; then mkdir -p /scratch/EPIC; ln -sf /scratch/EPIC ./EPIC; fi
-    - du -hs /scratch/EPIC
     - ls -lrtha
   retry:
     max: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,7 @@ get_data:
     - mkdir "${DETECTOR_CONFIG}"
     - ln -s "${LOCAL_DATA_PATH}/sim_output" "${DETECTOR_CONFIG}/sim_output"
     - ln -s "../results" "${DETECTOR_CONFIG}/results"
-    # cache downloaded artifacts
+    - mkdir -p "$SNAKEMAKE_OUTPUT_CACHE"
     - ls -lrtha
   retry:
     max: 2

--- a/Snakefile
+++ b/Snakefile
@@ -24,6 +24,7 @@ def get_remote_path(path):
 rule fetch_epic:
     output:
         filepath="EPIC/{PATH}"
+    cache: True
     retries: 3
     shell: """
 xrdcp --debug 2 root://dtn-eic.jlab.org//work/eic2/{output.filepath} {output.filepath}

--- a/benchmarks/backgrounds/config.yml
+++ b/benchmarks/backgrounds/config.yml
@@ -5,7 +5,7 @@ sim:backgrounds:
     - mkdir -p $LOCAL_DATA_PATH/input
     - ln -s $LOCAL_DATA_PATH/input input
     - |
-      snakemake --cores 2 \
+      snakemake -cache --cores 2 \
         sim_output/$DETECTOR_CONFIG/backgrounds/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/electron/GETaLM1.0.0-1.0/10GeV/GETaLM1.0.0-1.0_ElectronBeamGas_10GeV_foam_emin10keV_run001.edm4hep.root \
         sim_output/$DETECTOR_CONFIG/backgrounds/EPIC/EVGEN/DIS/NC/10x100/minQ2=1/pythia8NCDIS_10x100_minQ2=1_beamEffects_xAngle=-0.025_hiDiv_1.edm4hep.root \
         sim_output/$DETECTOR_CONFIG/backgrounds/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/proton/pythia8.306-1.0/100GeV/pythia8.306-1.0_ProtonBeamGas_100GeV_run001.edm4hep.root
@@ -28,7 +28,6 @@ collect_results:backgrounds:
     - "bench:backgrounds_emcal_backwards"
   script:
     - ls -lrht
-    - rm EPIC # remove the symlink to preserve the shared files
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake --cores 1 --delete-all-output backgrounds_ecal_backwards
     - mv results{_save,}/

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -16,7 +16,7 @@ sim:backwards_ecal:
         ]
   script:
     - |
-      snakemake --cores 5 sim_output/backwards_ecal/${DETECTOR_CONFIG}/${PARTICLE}/${MOMENTUM}/130to177deg/flag
+      snakemake --cache --cores 5 sim_output/backwards_ecal/${DETECTOR_CONFIG}/${PARTICLE}/${MOMENTUM}/130to177deg/flag
 
 bench:backwards_ecal:
   extends: .det_benchmark
@@ -35,7 +35,6 @@ collect_results:backwards_ecal:
     - "bench:backwards_ecal"
   script:
     - ls -lrht
-    - rm EPIC # remove the symlink to preserve the shared files
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake --cores 1 --delete-all-output backwards_ecal
     - mv results{_save,}/

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -4,7 +4,7 @@ sim:ecal_gaps:
   script:
     - mkdir -p $LOCAL_DATA_PATH/input
     - ln -s $LOCAL_DATA_PATH/input input
-    - snakemake --cores 10 ecal_gaps --omit-from ecal_gaps
+    - snakemake --cache --cores 10 ecal_gaps --omit-from ecal_gaps
 
 bench:ecal_gaps:
   extends: .det_benchmark
@@ -24,7 +24,6 @@ collect_results:ecal_gaps:
     - "bench:ecal_gaps"
   script:
     - ls -lrht
-    - rm EPIC # remove the symlink to preserve the shared files
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake --cores 1 --delete-all-output ecal_gaps
     - mv results{_save,}/

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -7,7 +7,7 @@ sim:tracking_performance:
         MOMENTUM: ["500MeV", "1GeV", "2GeV", "5GeV", "10GeV", "20GeV"]
   script:
     - |
-      snakemake --cores 1 \
+      snakemake --cache --cores 1 \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.tree.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.tree.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.tree.edm4eic.root
@@ -43,7 +43,6 @@ collect_results:tracking_performance_campaigns:
     - "bench:tracking_performance_campaigns"
   script:
     - ls -lrht
-    - rm EPIC # remove the symlink to preserve the shared files
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake --cores 1 --delete-all-output tracking_performance_campaigns
     - mv results{_save,}/

--- a/benchmarks/zdc_lyso/config.yml
+++ b/benchmarks/zdc_lyso/config.yml
@@ -2,7 +2,7 @@ sim:zdc_lyso:
   extends: .det_benchmark
   stage: simulate
   script:
-    - snakemake --cores 1 zdc_lyso_local
+    - snakemake --cache --cores 1 zdc_lyso_local
   retry:
     max: 2
     when:
@@ -15,7 +15,6 @@ collect_results:zdc_lyso:
     - "sim:zdc_lyso"
   script:
     - ls -lrht
-    - rm EPIC # remove the symlink to preserve the shared files
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake --cores 1 --delete-all-output zdc_lyso_local
     - mv results{_save,}/


### PR DESCRIPTION
If #43 is indeed caused by wiped common files, we can't store those on /scratch, but we also would like to cache those downloads, if possible.