### PR TITLE
.gitlab-ci.yml: deploy results to XRootD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,6 +147,7 @@ include:
   - local: 'benchmarks/b0_tracker/config.yml'
 
 deploy_results:
+  allow_failure: true
   stage: deploy
   needs:
     - "collect_results:backgrounds"
@@ -163,6 +164,8 @@ deploy_results:
   script:
     - echo "deploy results!"
     - find results -print | sort | tee summary.txt
+    - xrdfs $XROOTD_RW_ENDPOINT mkdir $XROOTD_OUTPUT_PREFIX/pipeline-$CI_PIPELINE_ID
+    - xrdcp -r results $XROOTD_RW_ENDPOINT/$XROOTD_OUTPUT_PREFIX/pipeline-$CI_PIPELINE_ID
 
 benchmarks:detector:success:
   stage: status-report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,17 @@ include:
 deploy_results:
   stage: deploy
   needs:
-    - ["collect_results:zdc","collect_results:barrel_ecal","collect_results:barrel_hcal","collect_results:material_scan"]
+    - "collect_results:backgrounds"
+    - "collect_results:backwards_ecal"
+    - "collect_results:barrel_ecal"
+    - "collect_results:barrel_hcal"
+    - "collect_results:ecal_gaps"
+    - "collect_results:material_scan"
+    - "collect_results:pid"
+    - "collect_results:tracking_performance"
+    - "collect_results:tracking_performance_campaigns"
+    - "collect_results:zdc"
+    - "collect_results:zdc_lyso"
   script:
     - echo "deploy results!"
     - find results -print | sort | tee summary.txt


### PR DESCRIPTION
We are looking to integrate eicweb with image_browser. Writing results to XRootD may be a good way to provide them to the service.

`allow_failure` is enabled to allow some tolerance for tokens that will be expiring.