### PR TITLE
mirror.yaml: add github.event_name to concurrency::group

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: mirror
+  group: mirror-${{ github.event_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Looks like we lost some PR due to cancellation
https://github.com/eic/detector_benchmarks/actions/runs/10968859151
It might be that merges are conflicting with themselves or with delete.