### PR TITLE
backwards_ecal,ecal_gaps: install python dependencies to venv

### DIFF
--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -24,7 +24,8 @@ bench:backwards_ecal:
   needs:
     - ["sim:backwards_ecal"]
   script:
-    - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
+    - unset PYTHONPATH
+    - python -m venv .venv; source .venv/bin/activate
     - pip install -r benchmarks/backwards_ecal/requirements.txt
     - snakemake --cores 1 backwards_ecal
 

--- a/benchmarks/backwards_ecal/requirements.txt
+++ b/benchmarks/backwards_ecal/requirements.txt
@@ -1,4 +1,6 @@
 awkward >= 2.4.0
+matplotlib
+numpy
 scikit-learn
-uproot >= 5.2.0
+uproot
 vector

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -13,7 +13,8 @@ bench:ecal_gaps:
     - ["sim:ecal_gaps"]
   script:
     - ln -s $LOCAL_DATA_PATH/input input
-    - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
+    - unset PYTHONPATH
+    - python -m venv .venv; source .venv/bin/activate
     - pip install -r benchmarks/ecal_gaps/requirements.txt
     - snakemake --cores 8 ecal_gaps
 

--- a/benchmarks/ecal_gaps/requirements.txt
+++ b/benchmarks/ecal_gaps/requirements.txt
@@ -3,5 +3,7 @@ dask >= 2023
 dask_awkward
 dask_histogram
 distributed >= 2023
+matplotlib
+numpy
 pyhepmc
-uproot ~= 5.2.0
+uproot


### PR DESCRIPTION
This should skip any dependencies from spack.