### PR TITLE
Snakefile: fix caching in fetch_epic

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -34,7 +34,7 @@ def get_remote_path(path):
 rule fetch_epic:
     output:
         filepath="EPIC/{PATH}"
-     params:
+    params:
         # wildcards are not included in hash for caching, we need to add them as params
         PATH=lambda wildcards: wildcards.PATH
     cache: True

--- a/Snakefile
+++ b/Snakefile
@@ -34,6 +34,9 @@ def get_remote_path(path):
 rule fetch_epic:
     output:
         filepath="EPIC/{PATH}"
+     params:
+        # wildcards are not included in hash for caching, we need to add them as params
+        PATH=lambda wildcards: wildcards.PATH
     cache: True
     retries: 3
     shell: """


### PR DESCRIPTION
This fixes a major bug, which causes all fetch_epic outputs to be cached under the same name.