### PR TITLE
**/config.yml: collect_results shoud extend from .det_benchmark

### DIFF
--- a/benchmarks/femc_electron/config.yml
+++ b/benchmarks/femc_electron/config.yml
@@ -1,6 +1,6 @@
 sim:femc_electron:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 10
@@ -20,13 +20,14 @@ sim:femc_electron:
       - runner_system_failure
 
 bench:femc_electron:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:femc_electron"]
   script:
     - snakemake --cores 1 results/epic_craterlake/femc_electron
 
 collect_results:femc_electron:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:femc_electron"]
   script:

--- a/benchmarks/femc_photon/config.yml
+++ b/benchmarks/femc_photon/config.yml
@@ -1,6 +1,6 @@
 sim:femc_photon:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 10
@@ -20,13 +20,14 @@ sim:femc_photon:
       - runner_system_failure
 
 bench:femc_photon:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:femc_photon"]
   script:
     - snakemake --cores 1 results/epic_craterlake/femc_photon
 
 collect_results:femc_photon:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:femc_photon"]
   script:

--- a/benchmarks/femc_pi0/config.yml
+++ b/benchmarks/femc_pi0/config.yml
@@ -1,6 +1,6 @@
 sim:femc_pi0:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 10
@@ -11,7 +11,6 @@ sim:femc_pi0:
       - P: 60
       - P: 70
       - P: 80
-  timeout: 1 hours
   script:
     - snakemake --cores 1 sim_output/femc_pi0/epic_craterlake_rec_pi0_${P}GeV.edm4eic.root
   retry:
@@ -20,13 +19,14 @@ sim:femc_pi0:
       - runner_system_failure
 
 bench:femc_pi0:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:femc_pi0"]
   script:
     - snakemake --cores 1 results/epic_craterlake/femc_pi0
 
 collect_results:femc_pi0:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:femc_pi0"]
   script:

--- a/benchmarks/insert_muon/config.yml
+++ b/benchmarks/insert_muon/config.yml
@@ -1,6 +1,6 @@
 sim:insert_muon:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 50
@@ -12,13 +12,14 @@ sim:insert_muon:
       - runner_system_failure
 
 bench:insert_muon:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:insert_muon"]
   script:
     - snakemake --cores 1 results/epic_craterlake/insert_muon
 
 collect_results:insert_muon:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:insert_muon"]
   script:

--- a/benchmarks/insert_neutron/config.yml
+++ b/benchmarks/insert_neutron/config.yml
@@ -1,6 +1,6 @@
 sim:insert_neutron:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 20
@@ -18,13 +18,14 @@ sim:insert_neutron:
       - runner_system_failure
 
 bench:insert_neutron:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:insert_neutron"]
   script:
     - snakemake --cores 1 results/epic_craterlake/insert_neutron
 
 collect_results:insert_neutron:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:insert_neutron"]
   script:

--- a/benchmarks/zdc_lambda/config.yml
+++ b/benchmarks/zdc_lambda/config.yml
@@ -1,6 +1,6 @@
 sim:zdc_lambda:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 100
@@ -19,13 +19,14 @@ sim:zdc_lambda:
       - runner_system_failure
 
 bench:zdc_lambda:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:zdc_lambda"]
   script:
     - snakemake --cores 1 results/epic_zdc_sipm_on_tile_only/zdc_lambda
 
 collect_results:zdc_lambda:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:zdc_lambda"]
   script:

--- a/benchmarks/zdc_photon/config.yml
+++ b/benchmarks/zdc_photon/config.yml
@@ -1,6 +1,6 @@
 sim:zdc_photon:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 20
@@ -19,14 +19,15 @@ sim:zdc_photon:
       - runner_system_failure
 
 bench:zdc_photon:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:zdc_photon"]
   script:
     - mkdir -p results/epic_zdc_sipm_on_tile_only
     - python benchmarks/zdc_photon/analysis/zdc_photon_plots.py results/epic_zdc_sipm_on_tile_only/zdc_photon
 
 collect_results:zdc_photon:
+  extends: .det_benchmark
   stage: collect
   extends: .det_benchmark
   needs: ["bench:zdc_photon"]

--- a/benchmarks/zdc_pi0/config.yml
+++ b/benchmarks/zdc_pi0/config.yml
@@ -1,6 +1,6 @@
 sim:zdc_pi0:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 60
@@ -16,17 +16,16 @@ sim:zdc_pi0:
       - runner_system_failure
 
 bench:zdc_pi0:
-  stage: benchmarks
-  
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:zdc_pi0"]
   script:
     - mkdir -p results/epic_zdc_sipm_on_tile_only
     - python benchmarks/zdc_pi0/analysis/zdc_pi0_plots.py results/epic_zdc_sipm_on_tile_only/zdc_pi0
 
 collect_results:zdc_pi0:
-  stage: collect
   extends: .det_benchmark
+  stage: collect
   needs: ["bench:zdc_pi0"]
   script:
     - ls -al

--- a/benchmarks/zdc_sigma/config.yml
+++ b/benchmarks/zdc_sigma/config.yml
@@ -1,6 +1,6 @@
 sim:zdc_sigma:
-  stage: simulate
   extends: .det_benchmark
+  stage: simulate
   parallel:
     matrix:
       - P: 100
@@ -19,13 +19,14 @@ sim:zdc_sigma:
       - runner_system_failure
 
 bench:zdc_sigma:
-  stage: benchmarks
   extends: .det_benchmark
+  stage: benchmarks
   needs: ["sim:zdc_sigma"]
   script:
     - snakemake --cores 1 results/epic_zdc_sipm_on_tile_only/zdc_sigma
 
 collect_results:zdc_sigma:
+  extends: .det_benchmark
   stage: collect
   needs: ["bench:zdc_sigma"]
   script:


### PR DESCRIPTION
This is needed for cleanup to work (.det_benchark symlinks sim_outputs to scratch). We have been overfilling scratch and femc benchmarks produce largest edm4hep files (HitContributions at 80GeV).