### PR TITLE
Add a basic .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-added-large-files
+        args: ['--maxkb=128']
+    -   id: check-yaml

--- a/benchmarks/zdc_photon/config.yml
+++ b/benchmarks/zdc_photon/config.yml
@@ -29,7 +29,6 @@ bench:zdc_photon:
 collect_results:zdc_photon:
   extends: .det_benchmark
   stage: collect
-  extends: .det_benchmark
   needs: ["bench:zdc_photon"]
   script:
     - ls -al


### PR DESCRIPTION
Originally, pre-commit-ci enabled for #86, which is not ready. Let's add some configuration for now.