### PR TITLE
.gitlab-ci.yml: add lfhcal to deploy_results

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,7 @@ deploy_results:
     - "collect_results:backwards_ecal"
     - "collect_results:barrel_ecal"
     - "collect_results:barrel_hcal"
+    - "collect_results:lfhcal"
     - "collect_results:ecal_gaps"
     - "collect_results:material_scan"
     - "collect_results:pid"


### PR DESCRIPTION
This is needed to have those uploaded to the image_browser.