### PR TITLE
Adding resolutions of DCAT and DCAz to the benchmark

### DIFF
--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -12,7 +12,7 @@ rule tracking_performance_sim:
         PHASE_SPACE="(3to50|45to135|130to177)deg",
         INDEX="\d{4}",
     params:
-        N_EVENTS=10000
+        N_EVENTS=50000
     shell:
         """
 set -m # monitor mode to prevent lingering processes
@@ -94,15 +94,31 @@ rule tracking_performance_summary_at_eta:
             ],
             MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 20.0],
         ),
-        script="benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C",
+        script_mom="benchmarks/tracking_performances/doCompare_truth_real_widebins_mom.C",
+        script_dcaT="benchmarks/tracking_performances/doCompare_truth_real_widebins_dcaT.C",
+        script_dcaz="benchmarks/tracking_performances/doCompare_truth_real_widebins_dcaz.C",
     output:
         expand(
             "{{CAMPAIGN}}/Debug_Plots/{SEEDING}/pi-/mom/{SEEDING}_mom_resol_mom{MOMENTUM:.1f}_{{ETA_MIN}}_eta_{{ETA_MAX}}.png",
             SEEDING=["real", "truth"],
             MOMENTUM=[0.5, 1.0, 2.0, 5.0, 10.0, 20.0],
         ),
+        expand(
+            "{{CAMPAIGN}}/Debug_Plots/{SEEDING}/pi-/dca/{SEEDING}_dcaxy_resol_mom{MOMENTUM:.1f}_{{ETA_MIN}}_eta_{{ETA_MAX}}.png",
+            SEEDING=["real", "truth"],
+            MOMENTUM=[0.2, 0.3, 0.5,1.0, 1.5, 2.0, 5.0, 8.0, 10., 15.0],
+        ),
+        expand(
+            "{{CAMPAIGN}}/Debug_Plots/{SEEDING}/pi-/dca/{SEEDING}_dcaz_resol_mom{MOMENTUM:.1f}_{{ETA_MIN}}_eta_{{ETA_MAX}}.png",
+            SEEDING=["real", "truth"],
+            MOMENTUM=[0.2, 0.3, 0.5,1.0, 1.5, 2.0, 5.0, 8.0, 10., 15.0],
+        ),
         "{CAMPAIGN}/Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.png",
         "{CAMPAIGN}/Final_Results/pi-/mom/mom_resol_{ETA_MIN}_eta_{ETA_MAX}.root",
+        "{CAMPAIGN}/Final_Results/pi-/dca/dcaxy_resol_{ETA_MIN}_eta_{ETA_MAX}.png", 
+        "{CAMPAIGN}/Final_Results/pi-/dca/dcaxy_resol_{ETA_MIN}_eta_{ETA_MAX}.root", 
+        "{CAMPAIGN}/Final_Results/pi-/dca/dcaz_resol_{ETA_MIN}_eta_{ETA_MAX}.png", 
+        "{CAMPAIGN}/Final_Results/pi-/dca/dcaz_resol_{ETA_MIN}_eta_{ETA_MAX}.root",    
     shell:
         """
 if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
@@ -119,8 +135,12 @@ if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
 else
 	EXTRA_LEGEND="ePIC Simulation {wildcards.CAMPAIGN}"
 fi
+hadd -f {wildcards.CAMPAIGN}/truthseed/pi-/dca/final_hist_dca_truthseed.root {wildcards.CAMPAIGN}/truthseed/pi-/dca/Performances_dca* 
+hadd -f {wildcards.CAMPAIGN}/realseed/pi-/dca/final_hist_dca_realseed.root {wildcards.CAMPAIGN}/realseed/pi-/dca/Performances_dca*            
 cd {wildcards.CAMPAIGN}
-root -l -b -q ../{input.script}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1., true, "'"$EXTRA_LEGEND"'")'
+root -l -b -q ../{input.script_mom}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1., true, "'"$EXTRA_LEGEND"'")'
+root -l -b -q ../{input.script_dcaT}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, true, "'"$EXTRA_LEGEND"'")'
+root -l -b -q ../{input.script_dcaz}'("pi-", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, true, "'"$EXTRA_LEGEND"'")'
 """
 
 

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -12,7 +12,7 @@ rule tracking_performance_sim:
         PHASE_SPACE="(3to50|45to135|130to177)deg",
         INDEX="\d{4}",
     params:
-        N_EVENTS=50000
+        N_EVENTS=10000
     shell:
         """
 set -m # monitor mode to prevent lingering processes

--- a/benchmarks/tracking_performances/doCompare_truth_real_widebins_dcaT.C
+++ b/benchmarks/tracking_performances/doCompare_truth_real_widebins_dcaT.C
@@ -9,7 +9,7 @@
 #include "TMath.h"
 
 void draw_req_DCA(double etamin, double etamax, double xmin=0., double xmax=0.);
-void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, Bool_t drawreq=1, TString epic ="24.06.0", TString eicrecon = "v1.14.0") // name = p, pt for getting p or pt dependence fitted results
+void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, Bool_t drawreq=1, TString extra_legend = "") // name = p, pt for getting p or pt dependence fitted results
 {
 
 //=== style of the plot=========
@@ -33,10 +33,7 @@ void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-
    TString symbolname = "";
    if (particle == "pi-") symbolname = "#pi^{-}"; 
    else symbolname = particle;
-   // Write the parameters in text file (for comparison)
-   ofstream outfile;
-   outfile.open ("DCAT_resol.txt",ios_base::app);  
-   
+
    
    TF1 *f1=new TF1("f1","FitPointingAngle",0.,30.0,2);
    f1->SetParLimits(0,0.,50000);	
@@ -57,7 +54,8 @@ void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-
      lDCAT = new TLegend(0.65,0.80,0.90,0.93);
      lDCAT->SetTextSize(0.03);
      lDCAT->SetBorderSize(0);
-     lDCAT->SetHeader(Form("%s ePIC(%s/%s): %1.1f < #eta < %1.1f",symbolname.Data(),epic.Data(),eicrecon.Data(),etamin,etamax),"C");
+     lDCAT->SetHeader(extra_legend.Data(), "C");
+     lDCAT->AddEntry((TObject*)0, Form("%s, %1.1f < #eta < %1.1f", symbolname.Data(), etamin, etamax), "C");
       
       fDCA_truth = TFile::Open(Form("./truthseed/%s/dca/final_hist_dca_truthseed.root",particle.Data()));
       fDCA_real = TFile::Open(Form("./realseed/%s/dca/final_hist_dca_realseed.root",particle.Data()));
@@ -88,7 +86,7 @@ void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-
     histd0xy_truth_1d->SetTitle(Form("d0_{xy} (truth): %1.1f <#eta< %1.1f && %1.2f <p_{T}< %1.2f",etamin,etamax,ptmin,ptmax));   
     histd0xy_truth_1d->SetName(Form("eta_%1.1f_%1.1f_d0xy_truth_pt_%1.1f",etamin,etamax,pt[iptbin]));  
    
-   if (histd0xy_truth_1d->GetEntries()<100) continue;   
+  // if (histd0xy_truth_1d->GetEntries()<100) continue;   
    double mu_truth = histd0xy_truth_1d->GetMean(); 
    double sigma_truth = histd0xy_truth_1d->GetStdDev();
    func_truth->SetRange(mu_truth-2.0*sigma_truth,mu_truth+2.0*sigma_truth); // fit with in 2 sigma range
@@ -107,7 +105,7 @@ void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-
     histd0xy_real_1d->SetTitle(Form("d0_{xy} (real): %1.1f <#eta< %1.1f && %1.2f <p_{T}< %1.2f",etamin,etamax,ptmin,ptmax));   
     histd0xy_real_1d->SetName(Form("eta_%1.1f_%1.1f_d0xy_real_pt_%1.1f",etamin,etamax,pt[iptbin])); 
    
-   if (histd0xy_real_1d->GetEntries()<100) continue;    
+  // if (histd0xy_real_1d->GetEntries()<100) continue;    
    double mu_real = histd0xy_real_1d->GetMean(); 
    double sigma_real = histd0xy_real_1d->GetStdDev();
    func_real->SetRange(mu_real-2.0*sigma_real,mu_real+2.0*sigma_real); // fit with in 2 sigma range
@@ -183,16 +181,6 @@ void doCompare_truth_real_widebins_dcaT(TString particle = "pi-",double etamin=-
      draw_req_DCA(etamin,etamax,0.,mgDCAT->GetXaxis()->GetXmax());
      c_dcaxy->SaveAs(Form("Final_Results/%s/dca/dcaxy_resol_%1.1f_eta_%1.1f.png",particle.Data(),etamin,etamax));
  
-   // Write the numbers in output file for comparisons
-   outfile<<"ePIC"<<setw(20)<<epic.Data()<<setw(20)<<"EICRecon"<<setw(20)<<eicrecon.Data()<<endl;
-   outfile<<"Etamin"<<setw(20)<<"Etamax"<<setw(20)<<"Pt (GeV/c) \t"<<setw(20)<<"DCAT Resol #mum (Real)"<<endl;
-   for (Int_t i = 0; i<gr1->GetN(); ++i){
-   double x,ytrue, yreal;
-   gr2->GetPoint(i,x,yreal);  
-   outfile<<etamin<<setw(20)<<etamax<<setw(20)<<x<<setw(20)<<yreal<<endl;
-   } 
-    outfile.close();
-     
      fout->cd();
      mgDCAT->SetName(Form("dcaxy_resol_%1.1f_eta_%1.1f",etamin,etamax));
      mgDCAT->Write();

--- a/benchmarks/tracking_performances/doCompare_truth_real_widebins_dcaz.C
+++ b/benchmarks/tracking_performances/doCompare_truth_real_widebins_dcaz.C
@@ -10,7 +10,7 @@
 #define mpi 0.139  // 1.864 GeV/c^2
 
 void draw_req_DCA(double etamin, double etamax, double xmin=0., double xmax=0.);
-void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, Bool_t drawreq=1, TString epic ="", TString eicrecon = "") // name = p, pt for getting p or pt dependence fitted results
+void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, Bool_t drawreq=1, TString extra_legend = "") // name = p, pt for getting p or pt dependence fitted results
 {
 
 //=== style of the plot=========
@@ -33,9 +33,6 @@ void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-
    TString symbolname = "";
    if (particle == "pi-") symbolname = "#pi^{-}"; 
    else symbolname = particle;
-   // Write the parameters in text file (for comparison)
-   ofstream outfile;
-   outfile.open ("DCAZ_resol.txt",ios_base::app);  
    
    TF1 *f1=new TF1("f1","FitPointingAngle",0.,30.0,2);
    f1->SetParLimits(0,0.,50000);	
@@ -55,7 +52,8 @@ void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-
 	  lDCAZ = new TLegend(0.70,0.80,0.90,0.93);
 	  lDCAZ->SetTextSize(0.03);
 	  lDCAZ->SetBorderSize(0);
-	  lDCAZ->SetHeader(Form("%s ePIC(%s/%s): %1.1f < #eta < %1.1f",symbolname.Data(),epic.Data(),eicrecon.Data(),etamin,etamax),"C");
+    lDCAZ->SetHeader(extra_legend.Data(), "C");
+    lDCAZ->AddEntry((TObject*)0, Form("%s, %1.1f < #eta < %1.1f", symbolname.Data(), etamin, etamax), "C");
       
     fDCA_truth = TFile::Open(Form("./truthseed/%s/dca/final_hist_dca_truthseed.root",particle.Data()));
 	  fDCA_real = TFile::Open(Form("./realseed/%s/dca/final_hist_dca_realseed.root",particle.Data()));
@@ -85,7 +83,7 @@ void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-
     TH1D *histd0z_truth_1d = (TH1D*)hist_d0z_truth->ProjectionX(Form("histd0z_truth_eta%1.1f_%1.1f_pt%1.1f_%1.1f",etamin,etamax,ptmin,ptmax),etamin_bin,etamax_bin,ptmin_bin,ptmax_bin,"o");
     histd0z_truth_1d->SetTitle(Form("d0_{z} (truth): %1.1f <#eta< %1.1f && %1.2f <p_{T}< %1.2f",etamin,etamax,ptmin,ptmax));   
     histd0z_truth_1d->SetName(Form("eta_%1.1f_%1.1f_d0z_truth_pt_%1.1f",etamin,etamax,pt[iptbin]));  
-   if (histd0z_truth_1d->GetEntries()<100) continue;
+  // if (histd0z_truth_1d->GetEntries()<100) continue;
    double mu_truth = histd0z_truth_1d->GetMean(); 
    double sigma_truth = histd0z_truth_1d->GetStdDev();
    func_truth->SetRange(mu_truth-2.0*sigma_truth,mu_truth+2.0*sigma_truth); // fit with in 2 sigma range
@@ -104,7 +102,7 @@ void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-
     histd0z_real_1d->SetTitle(Form("d0_{z} (real): %1.1f <#eta< %1.1f && %1.2f <p_{T}< %1.2f",etamin,etamax,ptmin,ptmax));   
     histd0z_real_1d->SetName(Form("eta_%1.1f_%1.1f_d0z_real_pt_%1.1f",etamin,etamax,pt[iptbin])); 
    
-   if (histd0z_real_1d->GetEntries()<100) continue; 
+ //  if (histd0z_real_1d->GetEntries()<100) continue; 
    double mu_real = histd0z_real_1d->GetMean(); 
    double sigma_real = histd0z_real_1d->GetStdDev();
    func_real->SetRange(mu_real-2.0*sigma_real,mu_real+2.0*sigma_real); // fit with in 2 sigma range
@@ -180,16 +178,7 @@ void doCompare_truth_real_widebins_dcaz(TString particle = "pi-",double etamin=-
    //  draw_req_DCA(etamin,etamax,0.,mgDCAZ->GetXaxis()->GetXmax());
      c_dcaz->SaveAs(Form("Final_Results/%s/dca/dcaz_resol_%1.1f_eta_%1.1f.png",particle.Data(),etamin,etamax));
      
-   // Write the numbers in output file for comparisons
-   outfile<<"ePIC"<<setw(20)<<epic.Data()<<setw(20)<<"EICRecon"<<setw(20)<<eicrecon.Data()<<endl;
-   outfile<<"Etamin"<<setw(20)<<"Etamax"<<setw(20)<<"Pt (GeV/c) \t"<<setw(20)<<"DCAz Resol #mum (Real)"<<endl;
-   for (Int_t i = 0; i<gr1->GetN(); ++i){
-   double x,ytrue, yreal;
-   gr2->GetPoint(i,x,yreal);  
-   outfile<<etamin<<setw(20)<<etamax<<setw(20)<<x<<setw(20)<<yreal<<endl;
-   } 
-    outfile.close();
-    fout->cd();
+     fout->cd();
      mgDCAZ->SetName(Form("dcaz_resol_%1.1f_eta_%1.1f",etamin,etamax));
      mgDCAZ->Write();
      fout->Close();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
There is a further addition of tracking performance plots e.g. DCAT and DCAz. The code was tested for local rules and works fine. Since DCAT and DCAz distributions are the functions of transverse momentum, we need to use large statistics (in my case I used 50k events).  


![dcaxy_resol_1 0_eta_2 5](https://github.com/user-attachments/assets/e7f4b691-9391-4a31-acbe-c91a0d13fdd8)
![dcaxy_resol_2 5_eta_3 5](https://github.com/user-attachments/assets/e9d36e72-2247-4090-86c1-e2ad3cab3704)
![dcaxy_resol_-1 0_eta_1 0](https://github.com/user-attachments/assets/235cd969-b148-4139-968d-acbe87bfa78d)
![dcaxy_resol_-2 5_eta_-1 0](https://github.com/user-attachments/assets/ca8257e1-0949-49d1-a67a-e9ad35ff34cd)
![dcaxy_resol_-3 5_eta_-2 5](https://github.com/user-attachments/assets/d9af00cd-bcd7-4bf2-b9e7-f938c51961a1)
![dcaz_resol_1 0_eta_2 5](https://github.com/user-attachments/assets/93c32796-23f3-479b-8f69-e7e97390f5a0)
![dcaz_resol_2 5_eta_3 5](https://github.com/user-attachments/assets/a653290a-cccf-47aa-b92f-15f628d80357)
![dcaz_resol_-1 0_eta_1 0](https://github.com/user-attachments/assets/c85f7a1f-aaea-4224-8bf0-fb321be45d81)
![dcaz_resol_-2 5_eta_-1 0](https://github.com/user-attachments/assets/c2dcaada-54ef-4f6f-83ae-a9902cff36fb)
![dcaz_resol_-3 5_eta_-2 5](https://github.com/user-attachments/assets/ad4fc31a-9b68-4c80-a541-3f3a9897642a)


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No
