### PR TITLE
Adding Hitmap and Average Nhits vs Eta map

### DIFF
--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -1,0 +1,241 @@
+// Code to draw average number of hits vs eta at the generated level
+// Shyam Kumar; shyam055119@gmail.com; shyam.kumar@ba.infn.it
+void NhitsvsEta_ePIC(Double_t mom=0.5)
+  {
+  
+   gStyle->SetPalette(1);
+   gStyle->SetOptTitle(1);
+   gStyle->SetTitleOffset(.85,"X");gStyle->SetTitleOffset(1.0,"Y");
+   gStyle->SetTitleSize(.05,"X");gStyle->SetTitleSize(.05,"Y");
+   gStyle->SetLabelSize(.04,"X");gStyle->SetLabelSize(.04,"Y");
+   gStyle->SetHistLineWidth(2);
+   gStyle->SetOptFit(1);
+   gStyle->SetOptStat(0);
+   
+     // MC Track Properties
+    TFile* file = new TFile(Form("./sim%1.1f.edm4hep.root",mom)); // Tree with tracks and hits
+    TTreeReader myReader("events", file); // name of tree and file
+		
+   TTreeReaderArray<Float_t> charge(myReader, "MCParticles.charge"); 
+   TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x"); 
+   TTreeReaderArray<Double_t> vy_mc(myReader, "MCParticles.vertex.y"); 
+   TTreeReaderArray<Double_t> vz_mc(myReader, "MCParticles.vertex.z"); 
+   TTreeReaderArray<Float_t> px_mc(myReader, "MCParticles.momentum.x"); 
+   TTreeReaderArray<Float_t> py_mc(myReader, "MCParticles.momentum.y"); 
+   TTreeReaderArray<Float_t> pz_mc(myReader, "MCParticles.momentum.z"); 
+   TTreeReaderArray<Int_t> status(myReader, "MCParticles.generatorStatus"); 
+   TTreeReaderArray<Int_t> pdg(myReader, "MCParticles.PDG"); 
+
+  TTreeReaderArray<Double_t> *vtx_si_x, *vtx_si_y, *vtx_si_z;
+  TTreeReaderArray<Double_t> *barrel_si_x, *barrel_si_y, *barrel_si_z; 
+  TTreeReaderArray<Double_t> *disks_si_x, *disks_si_y, *disks_si_z; 
+  TTreeReaderArray<Double_t> *endcap_etof_x, *endcap_etof_y, *endcap_etof_z;
+  TTreeReaderArray<Double_t> *barrel_mm_x, *barrel_mm_y, *barrel_mm_z;
+  TTreeReaderArray<Double_t> *barrel_tof_x, *barrel_tof_y, *barrel_tof_z;
+  TTreeReaderArray<Double_t> *out_mm_x, *out_mm_y, *out_mm_z; 
+  TTreeReaderArray<Double_t> *endcap_fmm_x, *endcap_fmm_y, *endcap_fmm_z; 
+  TTreeReaderArray<Double_t> *endcap_bmm_x, *endcap_bmm_y, *endcap_bmm_z; 
+
+  // check the quality flag for hits from primary tracks
+  TTreeReaderArray<Int_t> *vtx_si_quality, *barrel_si_quality, *disks_si_quality, *endcap_etof_quality, *barrel_mm_quality, *barrel_tof_quality, *out_mm_quality, *endcap_fmm_quality,      *endcap_bmm_quality; 	
+
+
+   // Hits on detectors
+   // SVT IB
+   vtx_si_x = new TTreeReaderArray<Double_t>(myReader, "VertexBarrelHits.position.x"); 
+   vtx_si_y = new TTreeReaderArray<Double_t>(myReader, "VertexBarrelHits.position.y"); 
+   vtx_si_z = new TTreeReaderArray<Double_t>(myReader, "VertexBarrelHits.position.z"); 
+   vtx_si_quality = new TTreeReaderArray<Int_t>(myReader, "VertexBarrelHits.quality");
+   
+   // SVT OB
+   barrel_si_x = new TTreeReaderArray<Double_t>(myReader, "SiBarrelHits.position.x"); 
+   barrel_si_y = new TTreeReaderArray<Double_t>(myReader, "SiBarrelHits.position.y"); 
+   barrel_si_z = new TTreeReaderArray<Double_t>(myReader, "SiBarrelHits.position.z");
+   barrel_si_quality = new TTreeReaderArray<Int_t>(myReader, "SiBarrelHits.quality");
+   
+   // SVT Disks
+   disks_si_x = new TTreeReaderArray<Double_t>(myReader, "TrackerEndcapHits.position.x"); 
+   disks_si_y = new TTreeReaderArray<Double_t>(myReader, "TrackerEndcapHits.position.y"); 
+   disks_si_z = new TTreeReaderArray<Double_t>(myReader, "TrackerEndcapHits.position.z");
+   disks_si_quality = new TTreeReaderArray<Int_t>(myReader, "TrackerEndcapHits.quality");
+   
+   // ETOF Hits
+   endcap_etof_x = new TTreeReaderArray<Double_t>(myReader, "TOFEndcapHits.position.x"); 
+   endcap_etof_y = new TTreeReaderArray<Double_t>(myReader, "TOFEndcapHits.position.y"); 
+   endcap_etof_z = new TTreeReaderArray<Double_t>(myReader, "TOFEndcapHits.position.z");
+   endcap_etof_quality = new TTreeReaderArray<Int_t>(myReader, "TOFEndcapHits.quality"); 
+    
+   // Inner MPGD
+   barrel_mm_x = new TTreeReaderArray<Double_t>(myReader, "MPGDBarrelHits.position.x"); 
+   barrel_mm_y = new TTreeReaderArray<Double_t>(myReader, "MPGDBarrelHits.position.y"); 
+   barrel_mm_z = new TTreeReaderArray<Double_t>(myReader, "MPGDBarrelHits.position.z");
+   barrel_mm_quality = new TTreeReaderArray<Int_t>(myReader, "MPGDBarrelHits.quality");  
+   
+   // BarrelTOF
+   barrel_tof_x = new TTreeReaderArray<Double_t>(myReader, "TOFBarrelHits.position.x"); 
+   barrel_tof_y = new TTreeReaderArray<Double_t>(myReader, "TOFBarrelHits.position.y"); 
+   barrel_tof_z = new TTreeReaderArray<Double_t>(myReader, "TOFBarrelHits.position.z");
+   barrel_tof_quality = new TTreeReaderArray<Int_t>(myReader, "TOFBarrelHits.quality");  
+   
+    //Outer MPGD Hits
+   out_mm_x = new TTreeReaderArray<Double_t>(myReader, "OuterMPGDBarrelHits.position.x"); 
+   out_mm_y = new TTreeReaderArray<Double_t>(myReader, "OuterMPGDBarrelHits.position.y"); 
+   out_mm_z = new TTreeReaderArray<Double_t>(myReader, "OuterMPGDBarrelHits.position.z");
+   out_mm_quality = new TTreeReaderArray<Int_t>(myReader, "OuterMPGDBarrelHits.quality");
+   
+    //Forward MPGD 
+   endcap_fmm_x = new TTreeReaderArray<Double_t>(myReader, "ForwardMPGDEndcapHits.position.x"); 
+   endcap_fmm_y = new TTreeReaderArray<Double_t>(myReader, "ForwardMPGDEndcapHits.position.y"); 
+   endcap_fmm_z = new TTreeReaderArray<Double_t>(myReader, "ForwardMPGDEndcapHits.position.z");
+   endcap_fmm_quality = new TTreeReaderArray<Int_t>(myReader, "ForwardMPGDEndcapHits.quality");    
+   
+   //Backward MPGD 
+   endcap_bmm_x = new TTreeReaderArray<Double_t>(myReader, "BackwardMPGDEndcapHits.position.x"); 
+   endcap_bmm_y = new TTreeReaderArray<Double_t>(myReader, "BackwardMPGDEndcapHits.position.y"); 
+   endcap_bmm_z = new TTreeReaderArray<Double_t>(myReader, "BackwardMPGDEndcapHits.position.z");
+   endcap_bmm_quality = new TTreeReaderArray<Int_t>(myReader, "BackwardMPGDEndcapHits.quality"); 
+        
+
+   Double_t etamc = 0.; 
+   int iEvent=-1; 
+   
+   TCanvas * c1 = new TCanvas("c1","coutput",1400,1000);
+   c1->SetMargin(0.10, 0.05 ,0.1,0.07);
+   c1->SetGridx();
+   c1->SetGridy();
+  
+  TProfile* hits = new TProfile("hits","Nhits (#theta)",70,-3.5,3.5); 
+  hits->SetTitle(Form("p = %1.1f GeV/c;#eta_{mc};Nhits",mom));
+  hits->GetXaxis()->CenterTitle();
+  hits->GetYaxis()->CenterTitle();
+  hits->SetMinimum(0.);
+  
+    std::vector<TVector3> hitPos; // The ePIC tracker
+    double epsilon = 1.0e-5;
+    bool debug = true;
+    int nhits_SVTIB, nhits_SVTOB, nhits_InMPGD, nhits_BTOF, nhits_OutMPGD, nhits_SVTDisks, nhits_FwdMPGDDisks, nhits_BwdMPGDDisks, nhits_ETOF;
+    
+     while (myReader.Next()) 
+     {
+      hitPos.clear(); 
+      iEvent++;
+      printf("<--------------------Event No. %d---------------------> \n",iEvent);      
+      // Generated primary track
+      if (charge.GetSize()>1) continue; // skip event for larger than 1 tracks
+      Double_t eta_Track = 100.; // set it ouside from -3.5 to 3.5      
+      Double_t pmc = 0.;
+      for (int j = 0; j < charge.GetSize(); ++j){
+      
+      if (status[j] !=1) continue;
+      pmc = sqrt(px_mc[j]*px_mc[j]+py_mc[j]*py_mc[j]+pz_mc[j]*pz_mc[j]);   
+      Double_t pzmc = pz_mc[j];
+      Double_t etamc = -1.0*TMath::Log(TMath::Tan((TMath::ACos(pzmc/pmc))/2));
+      eta_Track = etamc;
+      Double_t particle = pdg[j];
+      }
+      if (fabs(eta_Track)>3.5) continue; //outside tracker acceptance
+      // Associated hits with the primary track of momentum (mom)
+      if (fabs(pmc-mom)> epsilon) continue; 
+    //  if (eta_Track<3.4) continue; // Debug for the hits in a given eta range
+      printf("Eta of the generated track: %f, Momentum (GeV/c): %f \n",eta_Track,pmc);
+     // ePIC SVT IB Tracker
+     for (int j = 0; j < vtx_si_x->GetSize(); ++j){
+       Double_t xhit = vtx_si_x->At(j); Double_t yhit = vtx_si_y->At(j); Double_t zhit = vtx_si_z->At(j);
+       Int_t quality = vtx_si_quality->At(j);
+       if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+     }
+     nhits_SVTIB =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("SVT IB Associated hits: %d \n",nhits_SVTIB);
+     
+     // ePIC SVT OB Tracker
+     for (int j = 0; j < barrel_si_x->GetSize(); ++j){
+       Double_t xhit = barrel_si_x->At(j); Double_t yhit = barrel_si_y->At(j); Double_t zhit = barrel_si_z->At(j);
+       Int_t quality = barrel_si_quality->At(j); 
+       if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+     }
+     nhits_SVTOB =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("SVT OB Associated hits: %d \n",nhits_SVTOB);  
+    
+    // Inner MPGD Tracker
+    for (int j = 0; j < barrel_mm_x->GetSize(); ++j){
+      Double_t xhit = barrel_mm_x->At(j); Double_t yhit = barrel_mm_y->At(j); Double_t zhit = barrel_mm_z->At(j);
+      Int_t quality = barrel_mm_quality->At(j); 
+      if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+    }
+     nhits_InMPGD =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("Inner MPGD Associated hits: %d \n",nhits_InMPGD);
+      
+    // Outer MPGD Tracker
+    for (int j = 0; j < out_mm_x->GetSize(); ++j){
+      Double_t xhit = out_mm_x->At(j); Double_t yhit = out_mm_y->At(j); Double_t zhit = out_mm_z->At(j);
+      Int_t quality = out_mm_quality->At(j);    
+      if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit)); 
+    }
+     nhits_OutMPGD =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("Outer MPGD Associated hits: %d \n",nhits_OutMPGD);
+         
+    // BTOF Tracker
+    for (int j = 0; j < barrel_tof_x->GetSize(); ++j){
+      Double_t xhit = barrel_tof_x->At(j); Double_t yhit = barrel_tof_y->At(j); Double_t zhit = barrel_tof_z->At(j);
+      Int_t quality = barrel_tof_quality->At(j); 
+      if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit)); 
+    }
+    
+     nhits_BTOF =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("BTOF Associated hits: %d \n",nhits_BTOF);
+   
+    // ePIC SVT Disks Hits
+    for (int j = 0; j < disks_si_x->GetSize(); ++j){
+      Int_t quality = disks_si_quality->At(j); 
+      Double_t xhit = disks_si_x->At(j); Double_t yhit = disks_si_y->At(j); Double_t zhit = disks_si_z->At(j);
+      if (quality==0 && zhit>0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+      else if (quality==0 && zhit<0) hitPos.push_back(TVector3(xhit,yhit,zhit));      
+    }
+    
+     nhits_SVTDisks =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("SVT Disks Associated hits: %d \n",nhits_SVTDisks);
+    
+     // ETOF Tracker (Forward)
+    for (int j = 0; j < endcap_etof_x->GetSize(); ++j){
+    Double_t xhit = endcap_etof_x->At(j); Double_t yhit = endcap_etof_y->At(j); Double_t zhit = endcap_etof_z->At(j);
+    Int_t quality = endcap_etof_quality->At(j);    
+    if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+    }  
+    
+     nhits_ETOF =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("ETOF Associated hits: %d \n",nhits_ETOF);
+     
+     // Forward MPGD
+    for (int j = 0; j < endcap_fmm_x->GetSize(); ++j){
+    Double_t xhit = endcap_fmm_x->At(j); Double_t yhit = endcap_fmm_y->At(j); Double_t zhit = endcap_fmm_z->At(j);
+    Int_t quality = endcap_fmm_quality->At(j);    
+    if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+    } 
+     nhits_FwdMPGDDisks =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("Forward MPGD Associated hits: %d \n",nhits_FwdMPGDDisks);
+    
+    // Backward MPGD
+    for (int j = 0; j < endcap_bmm_x->GetSize(); ++j){
+    Double_t xhit = endcap_bmm_x->At(j); Double_t yhit = endcap_bmm_y->At(j); Double_t zhit = endcap_bmm_z->At(j);
+    Int_t quality = endcap_bmm_quality->At(j);    
+    if (quality==0) hitPos.push_back(TVector3(xhit,yhit,zhit));
+    } 
+     
+     nhits_BwdMPGDDisks =  hitPos.size(); hitPos.clear();
+     if (debug)  printf("Backward MPGD Associated hits: %d \n",nhits_BwdMPGDDisks);
+   
+    int nhits = nhits_SVTIB + nhits_SVTOB + nhits_InMPGD + nhits_BTOF + nhits_OutMPGD + nhits_SVTDisks + nhits_FwdMPGDDisks + nhits_BwdMPGDDisks + nhits_ETOF;
+    if (nhits>0) hits->Fill(eta_Track,nhits); 
+    printf("Total Associated hits: %d \n",nhits);
+
+ }
+ 
+  c1->cd();
+  gPad->SetTicks(1,1);
+  hits->SetLineWidth(2);
+  hits->Draw("hist");
+  c1->SaveAs(Form("./Output/Nhitsvsmom%1.1f.png",mom));
+  c1->SaveAs(Form("./Output/Nhitsvsmom%1.1f.root",mom));
+}
+
+

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -115,14 +115,15 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
     std::vector<TVector3> hitPos; // The ePIC tracker
     double epsilon = 1.0e-5;
     Double_t pmc = 0.;
-    bool debug = true;
+    bool debug = false;
     int nhits_SVTIB, nhits_SVTOB, nhits_InMPGD, nhits_BTOF, nhits_OutMPGD, nhits_SVTDisks, nhits_FwdMPGDDisks, nhits_BwdMPGDDisks, nhits_ETOF;
     
      while (myReader.Next()) 
      {
-      hitPos.clear(); 
+      hitPos.clear(); debug = false;
+      if (iEvent<10) debug = true;
       iEvent++;
-      printf("<--------------------Event No. %d---------------------> \n",iEvent);      
+      if (debug) printf("<--------------------Event No. %d---------------------> \n",iEvent);      
       // Generated primary track
       if (charge.GetSize()>1) continue; // skip event for larger than 1 tracks
       Double_t eta_Track = 100.; // set it ouside from -3.5 to 3.5      
@@ -139,7 +140,7 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
       // Associated hits with the primary track of momentum (mom)
     //  if (fabs(pmc-mom)> epsilon) continue; 
     //  if (eta_Track<3.4) continue; // Debug for the hits in a given eta range
-      printf("Eta of the generated track: %f, Momentum (GeV/c): %f \n",eta_Track,pmc);
+      if (debug) printf("Eta of the generated track: %f, Momentum (GeV/c): %f \n",eta_Track,pmc);
      // ePIC SVT IB Tracker
      for (int j = 0; j < vtx_si_x->GetSize(); ++j){
        Double_t xhit = vtx_si_x->At(j); Double_t yhit = vtx_si_y->At(j); Double_t zhit = vtx_si_z->At(j);

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -238,7 +238,7 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
   hits->SetLineWidth(2);
   hits->Draw("hist");
   TPaveText *pt = new TPaveText(0.1, 0.95, 0.9, 1.0, "NDC");
-  pt->AddText(Form("p_{mc} = %1.1f (GeV/c)",pmc));
+  pt->AddText(Form("p_{mc} = %1.1f GeV/c",pmc));
   pt->SetBorderSize(0);     
   pt->SetFillStyle(0);      
   pt->SetTextAlign(23); 

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -1,6 +1,6 @@
 // Code to draw average number of hits vs eta at the generated level
 // Shyam Kumar; shyam055119@gmail.com; shyam.kumar@ba.infn.it
-void NhitsvsEta_ePIC(TString filePath="")
+void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefix=".")
   {
   
    gStyle->SetPalette(1);
@@ -17,9 +17,6 @@ void NhitsvsEta_ePIC(TString filePath="")
     TTreeReader myReader("events", file); // name of tree and file
     // Find the last occurrence of '/'
     Int_t lastSlashPos = filePath.Last('/');
-
-    // Extract the file name
-    TString filename = (lastSlashPos != kNPOS) ? filePath(lastSlashPos + 1, filePath.Length()) : filePath;
 
    TTreeReaderArray<Float_t> charge(myReader, "MCParticles.charge"); 
    TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x"); 
@@ -109,10 +106,8 @@ void NhitsvsEta_ePIC(TString filePath="")
    c1->SetGridx();
    c1->SetGridy();
    
-  filename.Resize(filename.Sizeof()-14); // keep filename up to energy
- 
   TProfile* hits = new TProfile("hits","Nhits (#theta)",70,-3.5,3.5); 
-  hits->SetTitle(Form("%s;#eta_{mc};Nhits",filename.Data()));
+  hits->SetTitle(Form("%s;#eta_{mc};Nhits",label.Data()));
   hits->GetXaxis()->CenterTitle();
   hits->GetYaxis()->CenterTitle();
   hits->SetMinimum(0.);
@@ -241,7 +236,7 @@ void NhitsvsEta_ePIC(TString filePath="")
   gPad->SetTicks(1,1);
   hits->SetLineWidth(2);
   hits->Draw("hist");
-  c1->SaveAs(Form("%s.png",filename.Data()));
-  c1->SaveAs(Form("Nhitsvsmom%s.root",filename.Data()));
+  c1->SaveAs(Form("%s/Nhits_vs_eta.png", output_prefix.Data()));
+  c1->SaveAs(Form("%s/Nhits_vs_eta.root", output_prefix.Data()));
 }
 

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -9,6 +9,7 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
    gStyle->SetTitleSize(.05,"X");gStyle->SetTitleSize(.05,"Y");
    gStyle->SetLabelSize(.04,"X");gStyle->SetLabelSize(.04,"Y");
    gStyle->SetHistLineWidth(2);
+   gStyle->SetTitleAlign(23);     
    gStyle->SetOptFit(1);
    gStyle->SetOptStat(0);
    
@@ -102,18 +103,18 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
    int iEvent=-1; 
    
    TCanvas * c1 = new TCanvas("c1","coutput",1400,1000);
-   c1->SetMargin(0.10, 0.05 ,0.1,0.07);
+   c1->SetMargin(0.10, 0.05 ,0.1,0.08);
    c1->SetGridx();
    c1->SetGridy();
    
-  TProfile* hits = new TProfile("hits","Nhits (#theta)",70,-3.5,3.5); 
-  hits->SetTitle(Form("%s;#eta_{mc};Nhits",label.Data()));
-  hits->GetXaxis()->CenterTitle();
-  hits->GetYaxis()->CenterTitle();
-  hits->SetMinimum(0.);
+    TProfile* hits = new TProfile("hits","Nhits (#theta)",70,-3.5,3.5);
+    hits->GetXaxis()->CenterTitle();
+    hits->GetYaxis()->CenterTitle();
+    hits->SetMinimum(0.); 
   
     std::vector<TVector3> hitPos; // The ePIC tracker
     double epsilon = 1.0e-5;
+    Double_t pmc = 0.;
     bool debug = true;
     int nhits_SVTIB, nhits_SVTOB, nhits_InMPGD, nhits_BTOF, nhits_OutMPGD, nhits_SVTDisks, nhits_FwdMPGDDisks, nhits_BwdMPGDDisks, nhits_ETOF;
     
@@ -125,7 +126,6 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
       // Generated primary track
       if (charge.GetSize()>1) continue; // skip event for larger than 1 tracks
       Double_t eta_Track = 100.; // set it ouside from -3.5 to 3.5      
-      Double_t pmc = 0.;
       for (int j = 0; j < charge.GetSize(); ++j){
       
       if (status[j] !=1) continue;
@@ -234,9 +234,16 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
  
   c1->cd();
   gPad->SetTicks(1,1);
+  hits->SetTitle(";#eta_{mc};Nhits");
   hits->SetLineWidth(2);
   hits->Draw("hist");
+  TPaveText *pt = new TPaveText(0.1, 0.95, 0.9, 1.0, "NDC");
+  pt->AddText(Form("p_{mc} = %1.1f (GeV/c)",pmc));
+  pt->SetBorderSize(0);     
+  pt->SetFillStyle(0);      
+  pt->SetTextAlign(23); 
+  pt->Draw();
+
   c1->SaveAs(Form("%s/Nhits_vs_eta.png", output_prefix.Data()));
   c1->SaveAs(Form("%s/Nhits_vs_eta.root", output_prefix.Data()));
 }
-

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -229,7 +229,6 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
    
     int nhits = nhits_SVTIB + nhits_SVTOB + nhits_InMPGD + nhits_BTOF + nhits_OutMPGD + nhits_SVTDisks + nhits_FwdMPGDDisks + nhits_BwdMPGDDisks + nhits_ETOF;
     if (nhits>0) hits->Fill(eta_Track,nhits); 
-    printf("Total Associated hits: %d \n",nhits);
 
  }
  

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -23,9 +23,9 @@ void NhitsvsEta_ePIC(TString filePath="", TString label="", TString output_prefi
    TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x"); 
    TTreeReaderArray<Double_t> vy_mc(myReader, "MCParticles.vertex.y"); 
    TTreeReaderArray<Double_t> vz_mc(myReader, "MCParticles.vertex.z"); 
-   TTreeReaderArray<Float_t> px_mc(myReader, "MCParticles.momentum.x"); 
-   TTreeReaderArray<Float_t> py_mc(myReader, "MCParticles.momentum.y"); 
-   TTreeReaderArray<Float_t> pz_mc(myReader, "MCParticles.momentum.z"); 
+   TTreeReaderArray<Double_t> px_mc(myReader, "MCParticles.momentum.x"); 
+   TTreeReaderArray<Double_t> py_mc(myReader, "MCParticles.momentum.y"); 
+   TTreeReaderArray<Double_t> pz_mc(myReader, "MCParticles.momentum.z"); 
    TTreeReaderArray<Int_t> status(myReader, "MCParticles.generatorStatus"); 
    TTreeReaderArray<Int_t> pdg(myReader, "MCParticles.PDG"); 
 

--- a/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
+++ b/benchmarks/tracking_performances/NhitsvsEta_ePIC.C
@@ -1,6 +1,6 @@
 // Code to draw average number of hits vs eta at the generated level
 // Shyam Kumar; shyam055119@gmail.com; shyam.kumar@ba.infn.it
-void NhitsvsEta_ePIC(Double_t mom=0.5)
+void NhitsvsEta_ePIC(TString filePath="")
   {
   
    gStyle->SetPalette(1);
@@ -13,9 +13,14 @@ void NhitsvsEta_ePIC(Double_t mom=0.5)
    gStyle->SetOptStat(0);
    
      // MC Track Properties
-    TFile* file = new TFile(Form("./sim%1.1f.edm4hep.root",mom)); // Tree with tracks and hits
+    TFile* file = new TFile(Form("%s",filePath.Data())); // Tree with tracks and hits
     TTreeReader myReader("events", file); // name of tree and file
-		
+    // Find the last occurrence of '/'
+    Int_t lastSlashPos = filePath.Last('/');
+
+    // Extract the file name
+    TString filename = (lastSlashPos != kNPOS) ? filePath(lastSlashPos + 1, filePath.Length()) : filePath;
+
    TTreeReaderArray<Float_t> charge(myReader, "MCParticles.charge"); 
    TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x"); 
    TTreeReaderArray<Double_t> vy_mc(myReader, "MCParticles.vertex.y"); 
@@ -103,9 +108,11 @@ void NhitsvsEta_ePIC(Double_t mom=0.5)
    c1->SetMargin(0.10, 0.05 ,0.1,0.07);
    c1->SetGridx();
    c1->SetGridy();
-  
+   
+  filename.Resize(filename.Sizeof()-14); // keep filename up to energy
+ 
   TProfile* hits = new TProfile("hits","Nhits (#theta)",70,-3.5,3.5); 
-  hits->SetTitle(Form("p = %1.1f GeV/c;#eta_{mc};Nhits",mom));
+  hits->SetTitle(Form("%s;#eta_{mc};Nhits",filename.Data()));
   hits->GetXaxis()->CenterTitle();
   hits->GetYaxis()->CenterTitle();
   hits->SetMinimum(0.);
@@ -135,7 +142,7 @@ void NhitsvsEta_ePIC(Double_t mom=0.5)
       }
       if (fabs(eta_Track)>3.5) continue; //outside tracker acceptance
       // Associated hits with the primary track of momentum (mom)
-      if (fabs(pmc-mom)> epsilon) continue; 
+    //  if (fabs(pmc-mom)> epsilon) continue; 
     //  if (eta_Track<3.4) continue; // Debug for the hits in a given eta range
       printf("Eta of the generated track: %f, Momentum (GeV/c): %f \n",eta_Track,pmc);
      // ePIC SVT IB Tracker
@@ -234,8 +241,7 @@ void NhitsvsEta_ePIC(Double_t mom=0.5)
   gPad->SetTicks(1,1);
   hits->SetLineWidth(2);
   hits->Draw("hist");
-  c1->SaveAs(Form("./Output/Nhitsvsmom%1.1f.png",mom));
-  c1->SaveAs(Form("./Output/Nhitsvsmom%1.1f.root",mom));
+  c1->SaveAs(Form("%s.png",filename.Data()));
+  c1->SaveAs(Form("Nhitsvsmom%s.root",filename.Data()));
 }
-
 

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -82,8 +82,8 @@ rule tracking_performance_hit_maps:
         "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.root",
     shell: """
 OUTPUT_PREFIX="$(dirname {output[0]})"
-root -l -b -q {input.script_hitsmap}'("{input.outsim}", "'$OUTPUT_PREFIX'")'
-root -l -b -q {input.script_nhits_eta}'("{input.outsim}", "{wildcards.MOMENTUM}", "'$OUTPUT_PREFIX'")'
+root -l -b -q {input.script_hitsmap}'("{input.sim_hadd}", "'$OUTPUT_PREFIX'")'
+root -l -b -q {input.script_nhits_eta}'("{input.sim_hadd}", "{wildcards.MOMENTUM}", "'$OUTPUT_PREFIX'")'
 """
 
 rule tracking_performance_at_momentum:

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -45,10 +45,35 @@ exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
   -Ppodio:output_collections=MCParticles,CentralCKFTrajectories,CentralCKFTrackParameters,CentralCKFSeededTrackParameters,CentralCKFTruthSeededTrackParameters,CentralTrackVertices
 """
 
+rule tracking_performance_sim_hadd:
+    input:
+        simoutput=lambda wildcards:
+          expand(
+              "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.edm4hep.root",
+              DETECTOR_CONFIG="epic_craterlake_tracking_only",
+              PARTICLE=wildcards.PARTICLE,
+              ENERGY=wildcards.ENERGY,
+              PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
+              INDEX=range(1),
+          )
+    output:
+        "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
+    shell:
+        """
+hadd {output} {input.simoutput}
+"""
 
 rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
+        script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
+        script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
+         outsim=lambda wildcards:
+          expand(
+             "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
+             DETECTOR_CONFIG="epic_craterlake_tracking_only", PARTICLE=wildcards.PARTICLE,
+             ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV")
+         if wildcards.CAMPAIGN == "local" else None,
         # TODO pass as a file list?
         sim=lambda wildcards:
           expand(
@@ -80,6 +105,8 @@ fi
 hadd {output.combined_root} {input.sim}
 cd {wildcards.CAMPAIGN}
 root -l -b -q ../{input.script}'("../{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, '$TRUTH_SEEDING')'
+root -l -b -q ../{input.script_hitsmap}'("../{input.outsim}")' 
+root -l -b -q ../{input.script_nhits_eta}'("../{input.outsim}")' 
 """
 
 

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -50,13 +50,13 @@ rule tracking_performance_sim_hadd:
         simoutput=lambda wildcards: expand(
               "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.edm4hep.root",
               DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG},
+              ENERGY=wildcards.ENERGY,
               PARTICLE=wildcards.PARTICLE,
-              ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
               PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
               INDEX=range(1),
           )
     output:
-        "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{MOMENTUM}/{PARTICLE}.{MOMENTUM}.edm4hep.root",
+        "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
     shell:
         """
 echo "Merging simulation files into: {output}"
@@ -68,28 +68,27 @@ rule tracking_performance_hit_maps:
         script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
         script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
         sim_hadd=lambda wildcards:
-            f"sim_output/tracking_performance/epic_craterlake_tracking_only/{wildcards.PARTICLE}/{wildcards.MOMENTUM}/{wildcards.PARTICLE}.{wildcards.MOMENTUM}.edm4hep.root"
+            f"sim_output/tracking_performance/epic_craterlake_tracking_only/{wildcards.PARTICLE}/{wildcards.ENERGY}/{wildcards.PARTICLE}.{wildcards.ENERGY}.edm4hep.root"
   
     output:
-        hitsxy_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsxy_dd4hep.png",
-        hitsxy_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsxy_dd4hep.root",
-        hitsrz_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsrz_dd4hep.png",
-        hitsrz_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsrz_dd4hep.root",
-        nhits_eta_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/Nhits_vs_eta.png",
-        nhits_eta_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/Nhits_vs_eta.root",
+        hitsxy_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsxy_dd4hep.png",
+        hitsxy_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsxy_dd4hep.root",
+        hitsrz_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsrz_dd4hep.png",
+        hitsrz_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsrz_dd4hep.root",
+        nhits_eta_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/Nhits_vs_eta.png",
+        nhits_eta_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/Nhits_vs_eta.root",
+    params:
+        MOMENTUM=lambda wildcards: str(float(wildcards.ENERGY.replace("GeV", "").replace("MeV", "e-3"))),
     shell: """
 OUTPUT_PREFIX="$(dirname {output.hitsxy_png})"
 echo "Generating hit maps and Nhits vs eta for: {input.sim_hadd}"
 root -l -b -q {input.script_hitsmap}'("{input.sim_hadd}", "'$OUTPUT_PREFIX'")'
-root -l -b -q {input.script_nhits_eta}'("{input.sim_hadd}", "{wildcards.MOMENTUM}", "'$OUTPUT_PREFIX'")'
+root -l -b -q {input.script_nhits_eta}'("{input.sim_hadd}", "{params.MOMENTUM}", "'$OUTPUT_PREFIX'")'
 """
 
 rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
-        hit_maps=lambda wildcards: [
-            f"results/hitmaps/{wildcards.CAMPAIGN}/{wildcards.SEEDING}/{wildcards.PARTICLE}/{wildcards.MOMENTUM}/Nhits_vs_eta.png"
-        ] if wildcards.CAMPAIGN == "local" else [],
         # TODO pass as a file list?
         sim=lambda wildcards:
           expand(

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -90,7 +90,7 @@ rule tracking_performance_hit_maps:
 echo "Merging simulation files into: {output}"
 hadd -f {output.sim_hadd} {input.sim}
 OUTPUT_PREFIX="$(dirname {output.hitsxy_png})"
-echo "Generating hit maps and Nhits vs eta for: {input.sim_hadd}"
+echo "Generating hit maps and Nhits vs eta for: {output.sim_hadd}"
 root -l -b -q {input.script_hitsmap}'("{output.sim_hadd}", "'$OUTPUT_PREFIX'")'
 root -l -b -q {input.script_nhits_eta}'("{output.sim_hadd}", "{params.MOMENTUM}", "'$OUTPUT_PREFIX'")'
 """

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -68,12 +68,14 @@ rule tracking_performance_at_momentum:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
         script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
         script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
-         outsim=lambda wildcards:
+        outsim=lambda wildcards:
           expand(
              "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
              DETECTOR_CONFIG="epic_craterlake_tracking_only", PARTICLE=wildcards.PARTICLE,
-             ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV")
-         if wildcards.CAMPAIGN == "local" else None,
+             ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
+          )
+          if wildcards.CAMPAIGN == "local" else
+          [],
         # TODO pass as a file list?
         sim=lambda wildcards:
           expand(

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -12,7 +12,7 @@ rule tracking_performance_sim:
         PHASE_SPACE="(3to50|45to135|130to177)deg",
         INDEX=r"\d{4}",
     params:
-        N_EVENTS=1
+        N_EVENTS=10000
     shell:
         """
 set -m # monitor mode to prevent lingering processes

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -1,6 +1,6 @@
 rule tracking_performance_sim:
     input:
-        steering_file=ancient("EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer"),
+        steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
@@ -10,9 +10,9 @@ rule tracking_performance_sim:
         PARTICLE="pi-",
         ENERGY="[0-9]+[kMG]eV",
         PHASE_SPACE="(3to50|45to135|130to177)deg",
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
-        N_EVENTS=10000
+        N_EVENTS=1
     shell:
         """
 set -m # monitor mode to prevent lingering processes
@@ -37,7 +37,7 @@ rule tracking_performance_recon:
     log:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     shell: """
 set -m # monitor mode to prevent lingering processes
 exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
@@ -47,41 +47,39 @@ exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
 
 rule tracking_performance_sim_hadd:
     input:
-        simoutput=lambda wildcards:
-          expand(
+        simoutput=lambda wildcards: expand(
               "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.edm4hep.root",
-              DETECTOR_CONFIG="epic_craterlake_tracking_only",
+              DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG},
               PARTICLE=wildcards.PARTICLE,
-              ENERGY=wildcards.ENERGY,
+              ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
               PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
               INDEX=range(1),
           )
     output:
-        "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
+        "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{MOMENTUM}/{PARTICLE}.{MOMENTUM}.edm4hep.root",
     shell:
         """
-hadd {output} {input.simoutput}
+echo "Merging simulation files into: {output}"
+hadd -f {output} {input.simoutput}
 """
 
 rule tracking_performance_hit_maps:
     input:
         script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
         script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
-        sim_hadd=expand(
-           "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{{MOMENTUM}}/{{PARTICLE}}.{{MOMENTUM}}.edm4hep.root",
-           DETECTOR_CONFIG="epic_craterlake_tracking_only",
-        )
+        sim_hadd=lambda wildcards:
+            f"sim_output/tracking_performance/epic_craterlake_tracking_only/{wildcards.PARTICLE}/{wildcards.MOMENTUM}/{wildcards.PARTICLE}.{wildcards.MOMENTUM}.edm4hep.root"
+  
     output:
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.png",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.eps",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.root",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.png",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.eps",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.root",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.png",
-        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.root",
+        hitsxy_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.png",
+        hitsxy_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.root",
+        hitsrz_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.png",
+        hitsrz_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.root",
+        nhits_eta_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.png",
+        nhits_eta_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.root",
     shell: """
-OUTPUT_PREFIX="$(dirname {output[0]})"
+OUTPUT_PREFIX="$(dirname {output.hitsxy_png})"
+echo "Generating hit maps and Nhits vs eta for: {input.sim_hadd}"
 root -l -b -q {input.script_hitsmap}'("{input.sim_hadd}", "'$OUTPUT_PREFIX'")'
 root -l -b -q {input.script_nhits_eta}'("{input.sim_hadd}", "{wildcards.MOMENTUM}", "'$OUTPUT_PREFIX'")'
 """
@@ -89,10 +87,9 @@ root -l -b -q {input.script_nhits_eta}'("{input.sim_hadd}", "{wildcards.MOMENTUM
 rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
-        hit_maps=lambda wildcards:
-          [ "{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.png".format(**wildcards) ]
-          if wildcards.CAMPAIGN == "local" else
-          [],
+        hit_maps=lambda wildcards: [
+            f"results/hitmaps/{wildcards.CAMPAIGN}/{wildcards.SEEDING}/pi-/{wildcards.MOMENTUM}/{wildcards.SEEDING_IGNORE}/{wildcards.PARTICLE}/Nhits_vs_eta.png"
+        ] if wildcards.CAMPAIGN == "local" else [],
         # TODO pass as a file list?
         sim=lambda wildcards:
           expand(
@@ -183,7 +180,7 @@ rule tracking_performance_summary_at_eta:
         "{CAMPAIGN}/Final_Results/pi-/dca/dcaz_resol_{ETA_MIN}_eta_{ETA_MAX}.png", 
         "{CAMPAIGN}/Final_Results/pi-/dca/dcaz_resol_{ETA_MIN}_eta_{ETA_MAX}.root",    
     shell:
-        """
+        r"""
 if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
         set +e
         EPIC_VERSION="${{DETECTOR_VERSION:-}}"
@@ -254,10 +251,6 @@ rule tracking_performance_campaigns:
         expand(
             "results/tracking_performances/{CAMPAIGN}",
             CAMPAIGN=[
-                "23.10.0",
-                "23.11.0",
-                "23.12.0",
-                "24.03.1",
-                "24.04.0",
+                "24.10.1",
             ],
         )

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -63,17 +63,34 @@ rule tracking_performance_sim_hadd:
 hadd {output} {input.simoutput}
 """
 
+rule tracking_performance_hit_maps:
+    input:
+        script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
+        script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
+        sim_hadd=expand(
+           "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{{MOMENTUM}}/{{PARTICLE}}.{{MOMENTUM}}.edm4hep.root",
+           DETECTOR_CONFIG="epic_craterlake_tracking_only",
+        )
+    output:
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.png",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.eps",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.root",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.png",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.eps",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.root",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.png",
+        "local/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.root",
+    shell: """
+OUTPUT_PREFIX="$(dirname {output[0]})"
+root -l -b -q {input.script_hitsmap}'("{input.outsim}", "'$OUTPUT_PREFIX'")'
+root -l -b -q {input.script_nhits_eta}'("{input.outsim}", "{wildcards.MOMENTUM}", "'$OUTPUT_PREFIX'")'
+"""
+
 rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
-        script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
-        script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
-        outsim=lambda wildcards:
-          expand(
-             "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
-             DETECTOR_CONFIG="epic_craterlake_tracking_only", PARTICLE=wildcards.PARTICLE,
-             ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
-          )
+        hit_maps=lambda wildcards:
+          [ "{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.png".format(**wildcards) ]
           if wildcards.CAMPAIGN == "local" else
           [],
         # TODO pass as a file list?
@@ -107,8 +124,6 @@ fi
 hadd {output.combined_root} {input.sim}
 cd {wildcards.CAMPAIGN}
 root -l -b -q ../{input.script}'("../{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, '$TRUTH_SEEDING')'
-root -l -b -q ../{input.script_hitsmap}'("../{input.outsim}")' 
-root -l -b -q ../{input.script_nhits_eta}'("../{input.outsim}")' 
 """
 
 

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -114,7 +114,7 @@ rule tracking_performance_at_momentum:
                 ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
                 PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
                 INDEX=range(1),
-                TREE_SUFFIX=".tree" if int(wildcards.CAMPAIGN[:2]) < 25 else "", # backwards compatibility
+                TREE_SUFFIX=".tree" if wildcards.CAMPAIGN != "local" and int(wildcards.CAMPAIGN[:2]) < 25 else "", # backwards compatibility
             ),
         ),
     output:

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -71,12 +71,12 @@ rule tracking_performance_hit_maps:
             f"sim_output/tracking_performance/epic_craterlake_tracking_only/{wildcards.PARTICLE}/{wildcards.MOMENTUM}/{wildcards.PARTICLE}.{wildcards.MOMENTUM}.edm4hep.root"
   
     output:
-        hitsxy_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.png",
-        hitsxy_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsxy_dd4hep.root",
-        hitsrz_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.png",
-        hitsrz_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/hitsrz_dd4hep.root",
-        nhits_eta_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.png",
-        nhits_eta_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/pi-/{MOMENTUM}/{SEEDING_IGNORE}/{PARTICLE}/Nhits_vs_eta.root",
+        hitsxy_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsxy_dd4hep.png",
+        hitsxy_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsxy_dd4hep.root",
+        hitsrz_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsrz_dd4hep.png",
+        hitsrz_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/hitsrz_dd4hep.root",
+        nhits_eta_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/Nhits_vs_eta.png",
+        nhits_eta_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{MOMENTUM}/Nhits_vs_eta.root",
     shell: """
 OUTPUT_PREFIX="$(dirname {output.hitsxy_png})"
 echo "Generating hit maps and Nhits vs eta for: {input.sim_hadd}"
@@ -88,7 +88,7 @@ rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
         hit_maps=lambda wildcards: [
-            f"results/hitmaps/{wildcards.CAMPAIGN}/{wildcards.SEEDING}/pi-/{wildcards.MOMENTUM}/{wildcards.SEEDING_IGNORE}/{wildcards.PARTICLE}/Nhits_vs_eta.png"
+            f"results/hitmaps/{wildcards.CAMPAIGN}/{wildcards.SEEDING}/{wildcards.PARTICLE}/{wildcards.MOMENTUM}/Nhits_vs_eta.png"
         ] if wildcards.CAMPAIGN == "local" else [],
         # TODO pass as a file list?
         sim=lambda wildcards:

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -45,67 +45,58 @@ exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
   -Ppodio:output_collections=MCParticles,CentralCKFTrajectories,CentralCKFTrackParameters,CentralCKFSeededTrackParameters,CentralCKFTruthSeededTrackParameters,CentralTrackVertices
 """
 
-rule tracking_performance_sim_hadd:
-    input:
-        simoutput=lambda wildcards: expand(
-              "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.edm4hep.root",
-              DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG},
-              ENERGY=wildcards.ENERGY,
-              PARTICLE=wildcards.PARTICLE,
-              PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
-              INDEX=range(1),
-          )
-    output:
-        "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root",
-    shell:
-        """
-echo "Merging simulation files into: {output}"
-hadd -f {output} {input.simoutput}
-"""
-
 rule tracking_performance_hit_maps:
     input:
         script_hitsmap="benchmarks/tracking_performances/draw_hits.C",
         script_nhits_eta="benchmarks/tracking_performances/NhitsvsEta_ePIC.C",
-        sim_hadd=lambda wildcards:
-            f"sim_output/tracking_performance/epic_craterlake_tracking_only/{wildcards.PARTICLE}/{wildcards.ENERGY}/{wildcards.PARTICLE}.{wildcards.ENERGY}.edm4hep.root"
-  
+        sim=lambda wildcards: expand(
+            "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.edm4hep.root",
+            DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG},
+            ENERGY=wildcards.ENERGY,
+            PARTICLE=wildcards.PARTICLE,
+            PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
+            INDEX=range(1),
+        ),
     output:
-        hitsxy_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsxy_dd4hep.png",
-        hitsxy_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsxy_dd4hep.root",
-        hitsrz_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsrz_dd4hep.png",
-        hitsrz_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/hitsrz_dd4hep.root",
-        nhits_eta_png="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/Nhits_vs_eta.png",
-        nhits_eta_root="results/hitmaps/{CAMPAIGN}/{SEEDING}/{PARTICLE}/{ENERGY}/Nhits_vs_eta.root",
+        hitsxy_png="local/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/hitsxy_dd4hep.png",
+        hitsxy_root="local/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/hitsxy_dd4hep.root",
+        hitsrz_png="local/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/hitsrz_dd4hep.png",
+        hitsrz_root="local/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/hitsrz_dd4hep.root",
+        nhits_eta_png="local/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/Nhits_vs_eta.png",
+        nhits_eta_root="local/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/Nhits_vs_eta.root",
+        sim_hadd=temporary("sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PARTICLE}.{ENERGY}.edm4hep.root"),
     params:
         MOMENTUM=lambda wildcards: str(float(wildcards.ENERGY.replace("GeV", "").replace("MeV", "e-3"))),
     shell: """
+echo "Merging simulation files into: {output}"
+hadd -f {output.sim_hadd} {input.sim}
 OUTPUT_PREFIX="$(dirname {output.hitsxy_png})"
 echo "Generating hit maps and Nhits vs eta for: {input.sim_hadd}"
-root -l -b -q {input.script_hitsmap}'("{input.sim_hadd}", "'$OUTPUT_PREFIX'")'
-root -l -b -q {input.script_nhits_eta}'("{input.sim_hadd}", "{params.MOMENTUM}", "'$OUTPUT_PREFIX'")'
+root -l -b -q {input.script_hitsmap}'("{output.sim_hadd}", "'$OUTPUT_PREFIX'")'
+root -l -b -q {input.script_nhits_eta}'("{output.sim_hadd}", "{params.MOMENTUM}", "'$OUTPUT_PREFIX'")'
 """
 
 rule tracking_performance_at_momentum:
     input:
         script="benchmarks/tracking_performances/Tracking_Performances.C",
         # TODO pass as a file list?
-        sim=lambda wildcards:
-          expand(
-              "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
-              DETECTOR_CONFIG="epic_craterlake_tracking_only",
-              ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
-              PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
-              INDEX=range(1),
-          )
-          if wildcards.CAMPAIGN == "local" else
-          ancient(expand(
-              "EPIC/RECO/{{CAMPAIGN}}/epic_craterlake/SINGLE/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
-              DETECTOR_CONFIG="epic_craterlake",
-              ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
-              PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
-              INDEX=range(1),
-          )),
+        sim=lambda wildcards: branch(
+            wildcards.CAMPAIGN == "local",
+            then=expand(
+                "sim_output/tracking_performance/{DETECTOR_CONFIG}/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
+                DETECTOR_CONFIG="epic_craterlake_tracking_only",
+                ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
+                PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
+                INDEX=range(1),
+            ),
+            otherwise=ancient(expand(
+                "EPIC/RECO/{{CAMPAIGN}}/epic_craterlake/SINGLE/{{PARTICLE}}/{ENERGY}/{PHASE_SPACE}/{{PARTICLE}}_{ENERGY}_{PHASE_SPACE}.{INDEX:04d}.eicrecon.tree.edm4eic.root",
+                DETECTOR_CONFIG="epic_craterlake",
+                ENERGY=f"{float(wildcards.MOMENTUM):.0f}GeV" if float(wildcards.MOMENTUM) >= 1 else f"{float(wildcards.MOMENTUM) * 1000:.0f}MeV",
+                PHASE_SPACE=["3to50deg", "45to135deg", "130to177deg"],
+                INDEX=range(1),
+            )),
+        )
     output:
         "{CAMPAIGN}/{SEEDING}/pi-/mom/Performances_mom_{MOMENTUM}_mom_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
         "{CAMPAIGN}/{SEEDING}/pi-/dca/Performances_dca_{MOMENTUM}_dca_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
@@ -231,6 +222,18 @@ rule tracking_performance:
             ],
             ETA_BIN=[f"{eta_min:.1f}_eta_{eta_max:.1f}" for eta_min, eta_max in zip(TRACKING_PERFORMANCE_ETA_BINS[:-1], TRACKING_PERFORMANCE_ETA_BINS[1:])],
         ),
+        lambda wildcards: branch(
+            wildcards.CAMPAIGN == "local",
+            then=[
+                "local/epic_craterlake_tracking_only/pi-/1GeV/hitsxy_dd4hep.png",
+                "local/epic_craterlake_tracking_only/pi-/1GeV/hitsxy_dd4hep.root",
+                "local/epic_craterlake_tracking_only/pi-/1GeV/hitsrz_dd4hep.png",
+                "local/epic_craterlake_tracking_only/pi-/1GeV/hitsrz_dd4hep.root",
+                "local/epic_craterlake_tracking_only/pi-/1GeV/Nhits_vs_eta.png",
+                "local/epic_craterlake_tracking_only/pi-/1GeV/Nhits_vs_eta.root",
+            ],
+            otherwise=[],
+        )
     output:
         directory("results/tracking_performances/{CAMPAIGN}/")
     shell:

--- a/benchmarks/tracking_performances/Tracking_Performances.C
+++ b/benchmarks/tracking_performances/Tracking_Performances.C
@@ -77,9 +77,9 @@ void Tracking_Performances(TString filename="tracking_output",TString particle="
    TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x"); 
    TTreeReaderArray<Double_t> vy_mc(myReader, "MCParticles.vertex.y"); 
    TTreeReaderArray<Double_t> vz_mc(myReader, "MCParticles.vertex.z"); 
-   TTreeReaderArray<Float_t> px_mc(myReader, "MCParticles.momentum.x"); 
-   TTreeReaderArray<Float_t> py_mc(myReader, "MCParticles.momentum.y"); 
-   TTreeReaderArray<Float_t> pz_mc(myReader, "MCParticles.momentum.z"); 
+   TTreeReaderArray<Double_t> px_mc(myReader, "MCParticles.momentum.x"); 
+   TTreeReaderArray<Double_t> py_mc(myReader, "MCParticles.momentum.y"); 
+   TTreeReaderArray<Double_t> pz_mc(myReader, "MCParticles.momentum.z"); 
    TTreeReaderArray<Int_t> status(myReader, "MCParticles.generatorStatus"); 
    TTreeReaderArray<Int_t> pdg(myReader, "MCParticles.PDG"); 
    TTreeReaderArray<Int_t> match_flag(myReader, Form("CentralCKF%sTrackParameters.type",tag.Data()));

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -12,18 +12,6 @@ sim:tracking_performance:
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.tree.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.tree.edm4eic.root
 
-bench:tracking_performance_hit_maps:
-  extends: .det_benchmark
-  stage: benchmarks
-  needs:
-    - "sim:tracking_performance"
-  parallel:
-    matrix:
-      - PARTICLE: ["pi-"]
-        MOMENTUM: ["500MeV", "1GeV", "2GeV", "5GeV", "10GeV", "20GeV"]
-  script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 2 results/hitmaps/local/truthseed/${PARTICLE}/${MOMENTUM}/Nhits_vs_eta.png
-
 bench:tracking_performance:
   extends: .det_benchmark
   stage: benchmarks
@@ -40,8 +28,6 @@ collect_results:tracking_performance:
     - "bench:tracking_performance_hit_maps"
   script:
     - ls -lrht
-    - mkdir -p results_collected
-    - cp -r results/hitmaps results_collected/hitmaps/
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output tracking_performance_local
     - mv results{_save,}/
@@ -49,7 +35,6 @@ collect_results:tracking_performance:
 bench:tracking_performance_campaigns:
   extends: .det_benchmark
   stage: benchmarks
-  #when: manual
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 tracking_performance_campaigns
 

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -15,6 +15,8 @@ sim:tracking_performance:
 bench:tracking_performance_hit_maps:
   extends: .det_benchmark
   stage: benchmarks
+  needs:
+    - "sim:tracking_performance"
   parallel:
     matrix:
       - PARTICLE: ["pi-"]

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -12,6 +12,17 @@ sim:tracking_performance:
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.tree.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.tree.edm4eic.root
 
+bench:tracking_performance_hit_maps:
+  extends: .det_benchmark
+  stage: benchmarks
+  parallel:
+    matrix:
+      - PARTICLE: ["pi-"]
+        MOMENTUM: ["0.5", "1", "2", "5", "10", "20"]
+  script:
+    - MOM_UNIT=$(awk -v m=$MOMENTUM 'BEGIN {printf "%.0f%s", (m<1?m*1000:m), (m<1?"MeV":"GeV")}')
+    - snakemake $SNAKEMAKE_FLAGS --cores 2 results/hitmaps/local/truthseed/${PARTICLE}/${MOMENTUM}/truth/${PARTICLE}/Nhits_vs_eta.png
+
 bench:tracking_performance:
   extends: .det_benchmark
   stage: benchmarks
@@ -25,9 +36,14 @@ collect_results:tracking_performance:
   stage: collect
   needs:
     - "bench:tracking_performance"
+    - "bench:tracking_performance_hit_maps"
   script:
     - ls -lrht
+    - mkdir -p results_collected
+    - cp -r results/hitmaps results_collected/hitmaps/
+    - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output tracking_performance_local
+    - mv results{_save,}/
 
 bench:tracking_performance_campaigns:
   extends: .det_benchmark

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -25,7 +25,6 @@ collect_results:tracking_performance:
   stage: collect
   needs:
     - "bench:tracking_performance"
-    - "bench:tracking_performance_hit_maps"
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -20,9 +20,8 @@ bench:tracking_performance_hit_maps:
   parallel:
     matrix:
       - PARTICLE: ["pi-"]
-        MOMENTUM: ["0.5", "1", "2", "5", "10", "20"]
+        MOMENTUM: ["500MeV", "1GeV", "2GeV", "5GeV", "10GeV", "20GeV"]
   script:
-    - MOM_UNIT=$(awk -v m=$MOMENTUM 'BEGIN {printf "%.0f%s", (m<1?m*1000:m), (m<1?"MeV":"GeV")}')
     - snakemake $SNAKEMAKE_FLAGS --cores 2 results/hitmaps/local/truthseed/${PARTICLE}/${MOMENTUM}/Nhits_vs_eta.png
 
 bench:tracking_performance:

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -23,7 +23,7 @@ bench:tracking_performance_hit_maps:
         MOMENTUM: ["0.5", "1", "2", "5", "10", "20"]
   script:
     - MOM_UNIT=$(awk -v m=$MOMENTUM 'BEGIN {printf "%.0f%s", (m<1?m*1000:m), (m<1?"MeV":"GeV")}')
-    - snakemake $SNAKEMAKE_FLAGS --cores 2 results/hitmaps/local/truthseed/${PARTICLE}/${MOMENTUM}/truth/${PARTICLE}/Nhits_vs_eta.png
+    - snakemake $SNAKEMAKE_FLAGS --cores 2 results/hitmaps/local/truthseed/${PARTICLE}/${MOMENTUM}/Nhits_vs_eta.png
 
 bench:tracking_performance:
   extends: .det_benchmark

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -153,8 +153,8 @@ void draw_hits(TString filename="")
         sim->Draw(tof_barrel_hitsrz_posR.Data(),"TOFBarrelHits.position.y>0","");
         sim->Draw(disks_si_hitsrz_posR.Data(),"TrackerEndcapHits.position.y>0","");
         sim->Draw(endcap_tof_hitsrz_posR.Data(),"TOFEndcapHits.position.y>0","");
-  sim->Draw(barrel_mpgd_out_hitsrz_posR.Data(),"OuterMPGDBarrelHits.position.y>0","");
-  sim->Draw(fwd_mpgd_hitsrz_posR.Data(),"ForwardMPGDEndcapHits.position.y>0","");
+        sim->Draw(barrel_mpgd_out_hitsrz_posR.Data(),"OuterMPGDBarrelHits.position.y>0","");
+        sim->Draw(fwd_mpgd_hitsrz_posR.Data(),"ForwardMPGDEndcapHits.position.y>0","");
         sim->Draw(bwd_mpgd_hitsrz_posR.Data(),"BackwardMPGDEndcapHits.position.y>0","");
 
     TString si_vtx_hitsrz_negR  ="-1.0*sqrt(VertexBarrelHits.position.x*VertexBarrelHits.position.x+VertexBarrelHits.position.y*VertexBarrelHits.position.y)*0.1:VertexBarrelHits.position.z*0.1>>hitsrz_vtx_si_1";

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -82,11 +82,11 @@ void draw_hits(TString filename="", TString output_prefix=".")
         hitsxy_barrel_mm_out->SetLineColor(kBlue-7);
         
         c1->cd();
-        hitsxy_vtx_si->Draw("SCAT");
-        hitsxy_barrel_si->Draw("SCAT same");
-        hitsxy_barrel_mm_in->Draw("SCAT same");
-        hitsxy_barrel_tof->Draw("SCAT same");
-        hitsxy_barrel_mm_out->Draw("SCAT same");
+        hitsxy_vtx_si->Draw("BOX");
+        hitsxy_barrel_si->Draw("BOX same");
+        hitsxy_barrel_mm_in->Draw("BOX same");
+        hitsxy_barrel_tof->Draw("BOX same");
+        hitsxy_barrel_mm_out->Draw("BOX same");
 
  TLegend *l= new TLegend(0.65,0.85,0.90,1.0);
  l->SetTextSize(0.025);
@@ -267,24 +267,24 @@ void draw_hits(TString filename="", TString output_prefix=".")
           hitsrz_bwd_mpgd_1->SetMarkerColor(kOrange);
 
         c2->cd();
-        hitsrz_vtx_si->Draw("SCAT");
-        hitsrz_vtx_si_1->Draw("SCAT same");
-        hitsrz_barrel_si->Draw("SCAT same");
-        hitsrz_barrel_si_1->Draw("SCAT same");
-        hitsrz_barrel_mm_in->Draw("SCAT same");
-        hitsrz_barrel_mm_in_1->Draw("SCAT same");
-        hitsrz_barrel_tof->Draw("SCAT same");
-        hitsrz_barrel_tof_1->Draw("SCAT same");
-        hitsrz_barrel_mm_out->Draw("SCAT same");
-        hitsrz_barrel_mm_out_1->Draw("SCAT same");
-        hitsrz_endcap_tof->Draw("SCAT same");
-        hitsrz_endcap_tof_1->Draw("SCAT same");
-        hitsrz_disks_si->Draw("SCAT same");
-        hitsrz_disks_si_1->Draw("SCAT same");
-        hitsrz_fwd_mpgd->Draw("SCAT same");
-        hitsrz_fwd_mpgd_1->Draw("SCAT same");
-        hitsrz_bwd_mpgd->Draw("SCAT same");
-        hitsrz_bwd_mpgd_1->Draw("SCAT same");
+        hitsrz_vtx_si->Draw("BOX");
+        hitsrz_vtx_si_1->Draw("BOX same");
+        hitsrz_barrel_si->Draw("BOX same");
+        hitsrz_barrel_si_1->Draw("BOX same");
+        hitsrz_barrel_mm_in->Draw("BOX same");
+        hitsrz_barrel_mm_in_1->Draw("BOX same");
+        hitsrz_barrel_tof->Draw("BOX same");
+        hitsrz_barrel_tof_1->Draw("BOX same");
+        hitsrz_barrel_mm_out->Draw("BOX same");
+        hitsrz_barrel_mm_out_1->Draw("BOX same");
+        hitsrz_endcap_tof->Draw("BOX same");
+        hitsrz_endcap_tof_1->Draw("BOX same");
+        hitsrz_disks_si->Draw("BOX same");
+        hitsrz_disks_si_1->Draw("BOX same");
+        hitsrz_fwd_mpgd->Draw("BOX same");
+        hitsrz_fwd_mpgd_1->Draw("BOX same");
+        hitsrz_bwd_mpgd->Draw("BOX same");
+        hitsrz_bwd_mpgd_1->Draw("BOX same");
 
   TLegend *l1= new TLegend(0.11,0.88,0.95,0.99);
   l1->SetNColumns(3);

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -8,7 +8,7 @@
 #include <TLegend.h>
 #include <TMath.h>
 
-void draw_hits(double mom=5.0)
+void draw_hits(TString filename="")
 {
 
 //==========Style of the plot============
@@ -22,7 +22,7 @@ void draw_hits(double mom=5.0)
    gStyle->SetOptStat(0);
 
 //=======Reading the root file DD4HEP===========
- TFile *f = TFile::Open(Form("sim%1.1f.edm4hep.root",mom));
+ TFile *f = TFile::Open(Form("%s",filename.Data()));
  TTree *sim = (TTree*)f->Get("events");
 
  // Timer Start

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -8,7 +8,7 @@
 #include <TLegend.h>
 #include <TMath.h>
 
-void draw_hits(TString filename="")
+void draw_hits(TString filename="", TString output_prefix=".")
 {
 
 //==========Style of the plot============
@@ -97,9 +97,9 @@ void draw_hits(TString filename="")
  l->AddEntry(hitsxy_barrel_tof,"TOFBarrelHits");
  l->AddEntry(hitsxy_barrel_mm_out,"OuterMPGDBarrelHits");
  l->Draw();
- c1->SaveAs("hitsxy_dd4hep.png");
- c1->SaveAs("hitsxy_dd4hep.eps");
- c1->SaveAs("hitsxy_dd4hep.root");
+ c1->SaveAs(Form("%s/hitsxy_dd4hep.png", output_prefix.Data()));
+ c1->SaveAs(Form("%s/hitsxy_dd4hep.eps", output_prefix.Data()));
+ c1->SaveAs(Form("%s/hitsxy_dd4hep.root", output_prefix.Data()));
 
   TCanvas *c2 = new TCanvas("c2","c2",1200,1000);
   c2->SetMargin(0.09, 0.03 ,0.1,0.06);
@@ -301,9 +301,9 @@ void draw_hits(TString filename="")
   l1->AddEntry(hitsrz_bwd_mpgd,"BackwardMPGDEndcapHits");
   l1->Draw();
 
-  c2->SaveAs("hitsrz_dd4hep.png");
-  c2->SaveAs("hitsrz_dd4hep.eps");  
-  c2->SaveAs("hitsrz_dd4hep.root");
+  c2->SaveAs(Form("%s/hitsrz_dd4hep.png", output_prefix.Data()));
+  c2->SaveAs(Form("%s/hitsrz_dd4hep.eps", output_prefix.Data()));
+  c2->SaveAs(Form("%s/hitsrz_dd4hep.root", output_prefix.Data()));
  // Timer Stop
   timer.Stop();
   Double_t realtime = timer.RealTime();

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -1,0 +1,313 @@
+// Hits distribution of detectors
+// Shyam Kumar:INFN Bari, shyam.kumar@ba.infn.it; shyam055119@gmail.com
+
+#include <TGraphErrors.h>
+#include <TF1.h>
+#include <TRandom.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <TMath.h>
+
+void draw_hits(double mom=5.0)
+{
+
+//==========Style of the plot============
+   gStyle->SetPalette(1);
+   gStyle->SetOptTitle(1);
+   gStyle->SetTitleOffset(.85,"X");gStyle->SetTitleOffset(.85,"Y");
+   gStyle->SetTitleSize(.04,"X");gStyle->SetTitleSize(.04,"Y");
+   gStyle->SetLabelSize(.04,"X");gStyle->SetLabelSize(.04,"Y");
+   gStyle->SetHistLineWidth(2);
+   gStyle->SetOptFit(1);
+   gStyle->SetOptStat(0);
+
+//=======Reading the root file DD4HEP===========
+ TFile *f = TFile::Open(Form("sim%1.1f.edm4hep.root",mom));
+ TTree *sim = (TTree*)f->Get("events");
+
+ // Timer Start
+  TStopwatch timer;
+  timer.Start();
+
+  TCanvas *c1 = new TCanvas("c1","c1",1200,1000);
+  c1->SetMargin(0.09, 0.03 ,0.1,0.06);
+
+ // X-Y Hits
+  Int_t nbins = 320;
+  Double_t x= 100., y = 100.;
+  TH2D *hitsxy_vtx_si = new TH2D("hitsxy_vtx_si","hitsxy_vtx_si",nbins,-x,x,nbins,-y,y);
+  TH2D *hitsxy_barrel_si = new TH2D("hitsxy_barrel_si","hitsxy_barrel_si",nbins,-x,x,nbins,-y,y);
+  TH2D *hitsxy_barrel_mm_in = new TH2D("hitsxy_barrel_mm_in","hitsxy_barrel_mm_in",nbins,-x,x,nbins,-y,y);
+  TH2D *hitsxy_barrel_tof = new TH2D("hitsxy_barrel_tof","hitsxy_barrel_tof",nbins,-x,x,nbins,-y,y);
+  TH2D *hitsxy_barrel_mm_out = new TH2D("hitsxy_barrel_mm_out","hitsxy_barrel_mm_out",nbins,-x,x,nbins,-y,y);
+
+  TString si_vtx_hitsXY ="VertexBarrelHits.position.y*0.1:VertexBarrelHits.position.x*0.1>>hitsxy_vtx_si";
+  TString si_barrel_hitsXY ="SiBarrelHits.position.y*0.1:SiBarrelHits.position.x*0.1>>hitsxy_barrel_si";
+  TString barrel_mpgd_in_hitsXY ="MPGDBarrelHits.position.y*0.1:MPGDBarrelHits.position.x*0.1>>hitsxy_barrel_mm_in";
+  TString tof_barrel_hitsXY ="TOFBarrelHits.position.y*0.1:TOFBarrelHits.position.x*0.1>>hitsxy_barrel_tof";
+  TString barrel_mpgd_out_hitsXY ="OuterMPGDBarrelHits.position.y*0.1:OuterMPGDBarrelHits.position.x*0.1>>hitsxy_barrel_mm_out";
+
+        sim->Draw(si_vtx_hitsXY.Data(),"",""); // Multiply by 0.1 for cm
+        sim->Draw(si_barrel_hitsXY.Data(),"","");
+        sim->Draw(barrel_mpgd_in_hitsXY.Data(),"","");
+        sim->Draw(tof_barrel_hitsXY.Data(),"","");
+        sim->Draw(barrel_mpgd_out_hitsXY.Data(),"","");
+
+        hitsxy_vtx_si->SetMarkerStyle(31);
+        hitsxy_vtx_si->SetTitle("Hit Points (XY)");
+        hitsxy_vtx_si->SetMarkerColor(kBlack);
+        hitsxy_vtx_si->SetMarkerSize(0.1);
+        hitsxy_vtx_si->SetLineColor(kBlack);
+        hitsxy_vtx_si->GetXaxis()->SetTitle("X [cm]");
+        hitsxy_vtx_si->GetYaxis()->SetTitle("Y [cm]");
+        hitsxy_vtx_si->GetXaxis()->CenterTitle();
+        hitsxy_vtx_si->GetYaxis()->CenterTitle();
+
+        hitsxy_barrel_si->SetMarkerStyle(20);
+        hitsxy_barrel_si->SetMarkerSize(0.1);
+        hitsxy_barrel_si->SetMarkerColor(kMagenta);
+        hitsxy_barrel_si->SetLineColor(kMagenta);
+
+        hitsxy_barrel_mm_in->SetMarkerStyle(20);
+        hitsxy_barrel_mm_in->SetMarkerSize(0.1);
+        hitsxy_barrel_mm_in->SetMarkerColor(kBlue);
+        hitsxy_barrel_mm_in->SetLineColor(kBlue);
+
+        hitsxy_barrel_tof->SetMarkerStyle(20);
+        hitsxy_barrel_tof->SetMarkerSize(0.1);
+        hitsxy_barrel_tof->SetMarkerColor(kGreen);
+        hitsxy_barrel_tof->SetLineColor(kGreen);hitsxy_barrel_mm_out->SetMarkerStyle(20);
+        hitsxy_barrel_mm_out->SetMarkerSize(0.1);
+        hitsxy_barrel_mm_out->SetMarkerColor(kBlue-7);
+        hitsxy_barrel_mm_out->SetLineColor(kBlue-7);
+        
+        c1->cd();
+        hitsxy_vtx_si->Draw();
+        hitsxy_barrel_si->Draw("same");
+        hitsxy_barrel_mm_in->Draw("same");
+        hitsxy_barrel_tof->Draw("same");
+        hitsxy_barrel_mm_out->Draw("same");
+
+ TLegend *l= new TLegend(0.65,0.85,0.90,1.0);
+ l->SetTextSize(0.025);
+ l->SetBorderSize(0);
+ l->AddEntry(hitsxy_vtx_si,"VertexBarrelHits");
+ l->AddEntry(hitsxy_barrel_si,"SiBarrelHits");
+ l->AddEntry(hitsxy_barrel_mm_in,"MPGDBarrelHits");
+ l->AddEntry(hitsxy_barrel_tof,"TOFBarrelHits");
+ l->AddEntry(hitsxy_barrel_mm_out,"OuterMPGDBarrelHits");
+ l->Draw();
+ c1->SaveAs("hitsxy_dd4hep.png");
+ c1->SaveAs("hitsxy_dd4hep.eps");
+ c1->SaveAs("hitsxy_dd4hep.root");
+
+  TCanvas *c2 = new TCanvas("c2","c2",1200,1000);
+  c2->SetMargin(0.09, 0.03 ,0.1,0.06);
+ // Y-Z Hits
+ Int_t nbinsx = 400, nbinsy=1800.;
+ x= 200.; y = 90.;
+ double xmin = -200.;
+
+   TH2D *hitsrz_vtx_si = new TH2D("hitsrz_vtx_si","hitsrz_vtx_si",nbinsx,xmin,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_si = new TH2D("hitsrz_barrel_si","hitsrz_barrel_si",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_mm_in = new TH2D("hitsrz_barrel_mm_in","hitsrz_barrel_mm_in",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_mm_out = new TH2D("hitsrz_barrel_mm_out","hitsrz_barrel_mm_out",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_tof = new TH2D("hitsrz_barrel_tof","hitsrz_barrel_tof",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_disks_si = new TH2D("hitsrz_disks_si","hitsrz_disks_si",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_endcap_tof = new TH2D("hitsrz_endcap_tof","hitsrz_endcap_tof",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_fwd_mpgd = new TH2D("hitsrz_fwd_mpgd","hitsrz_fwd_mpgd",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_bwd_mpgd = new TH2D("hitsrz_bwd_mpgd","hitsrz_bwd_mpgd",nbinsx,-x,x,nbinsy,-y,y);
+
+   TH2D *hitsrz_vtx_si_1 = new TH2D("hitsrz_vtx_si_1","hitsrz_vtx_si_1",nbinsx,xmin,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_si_1 = new TH2D("hitsrz_barrel_si_1","hitsrz_barrel_si_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_mm_in_1 = new TH2D("hitsrz_barrel_mm_in_1","hitsrz_barrel_mm_in_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_mm_out_1 = new TH2D("hitsrz_barrel_mm_out_1","hitsrz_barrel_mm_out_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_barrel_tof_1 = new TH2D("hitsrz_barrel_tof_1","hitsrz_barrel_tof_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_disks_si_1 = new TH2D("hitsrz_disks_si_1","hitsrz_disks_si_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_endcap_tof_1 = new TH2D("hitsrz_endcap_tof_1","hitsrz_endcap_tof_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_fwd_mpgd_1 = new TH2D("hitsrz_fwd_mpgd_1","hitsrz_fwd_mpgd_1",nbinsx,-x,x,nbinsy,-y,y);
+   TH2D *hitsrz_bwd_mpgd_1 = new TH2D("hitsrz_bwd_mpgd_1","hitsrz_bwd_mpgd_1",nbinsx,-x,x,nbinsy,-y,y);
+
+    TString si_vtx_hitsrz_posR  ="sqrt(VertexBarrelHits.position.x*VertexBarrelHits.position.x+VertexBarrelHits.position.y*VertexBarrelHits.position.y)*0.1:VertexBarrelHits.position.z*0.1>>hitsrz_vtx_si";
+
+    TString si_barrel_hitsrz_posR ="sqrt(SiBarrelHits.position.x*SiBarrelHits.position.x+SiBarrelHits.position.y*SiBarrelHits.position.y)*0.1:SiBarrelHits.position.z*0.1>>hitsrz_barrel_si";
+
+    TString barrel_mpgd_in_hitsrz_posR= "sqrt(MPGDBarrelHits.position.x*MPGDBarrelHits.position.x+MPGDBarrelHits.position.y*MPGDBarrelHits.position.y)*0.1:MPGDBarrelHits.position.z*0.1>>hitsrz_barrel_mm_in";
+
+    TString tof_barrel_hitsrz_posR ="sqrt(TOFBarrelHits.position.x*TOFBarrelHits.position.x+TOFBarrelHits.position.y*TOFBarrelHits.position.y)*0.1:TOFBarrelHits.position.z*0.1>>hitsrz_barrel_tof";
+
+    TString barrel_mpgd_out_hitsrz_posR ="sqrt(OuterMPGDBarrelHits.position.x*OuterMPGDBarrelHits.position.x+OuterMPGDBarrelHits.position.y*OuterMPGDBarrelHits.position.y)*0.1:OuterMPGDBarrelHits.position.z*0.1>>hitsrz_barrel_mm_out";
+
+    TString disks_si_hitsrz_posR ="sqrt(TrackerEndcapHits.position.x*TrackerEndcapHits.position.x+TrackerEndcapHits.position.y*TrackerEndcapHits.position.y)*0.1:TrackerEndcapHits.position.z*0.1>>hitsrz_disks_si";
+
+    TString endcap_tof_hitsrz_posR ="sqrt(TOFEndcapHits.position.x*TOFEndcapHits.position.x+TOFEndcapHits.position.y*TOFEndcapHits.position.y)*0.1:TOFEndcapHits.position.z*0.1>>hitsrz_endcap_tof";
+
+    TString fwd_mpgd_hitsrz_posR ="sqrt(ForwardMPGDEndcapHits.position.x*ForwardMPGDEndcapHits.position.x+ForwardMPGDEndcapHits.position.y*ForwardMPGDEndcapHits.position.y)*0.1:ForwardMPGDEndcapHits.position.z*0.1>>hitsrz_fwd_mpgd";
+
+    TString bwd_mpgd_hitsrz_posR ="sqrt(BackwardMPGDEndcapHits.position.x*BackwardMPGDEndcapHits.position.x+BackwardMPGDEndcapHits.position.y*BackwardMPGDEndcapHits.position.y)*0.1:BackwardMPGDEndcapHits.position.z*0.1>>hitsrz_bwd_mpgd";
+
+
+        sim->Draw(si_vtx_hitsrz_posR.Data(),"VertexBarrelHits.position.y>0",""); // Multiply by 0.1 for cm
+        sim->Draw(si_barrel_hitsrz_posR.Data(),"SiBarrelHits.position.y>0","");
+        sim->Draw(barrel_mpgd_in_hitsrz_posR.Data(),"MPGDBarrelHits.position.y>0","");
+        sim->Draw(tof_barrel_hitsrz_posR.Data(),"TOFBarrelHits.position.y>0","");
+        sim->Draw(disks_si_hitsrz_posR.Data(),"TrackerEndcapHits.position.y>0","");
+        sim->Draw(endcap_tof_hitsrz_posR.Data(),"TOFEndcapHits.position.y>0","");
+  sim->Draw(barrel_mpgd_out_hitsrz_posR.Data(),"OuterMPGDBarrelHits.position.y>0","");
+  sim->Draw(fwd_mpgd_hitsrz_posR.Data(),"ForwardMPGDEndcapHits.position.y>0","");
+        sim->Draw(bwd_mpgd_hitsrz_posR.Data(),"BackwardMPGDEndcapHits.position.y>0","");
+
+    TString si_vtx_hitsrz_negR  ="-1.0*sqrt(VertexBarrelHits.position.x*VertexBarrelHits.position.x+VertexBarrelHits.position.y*VertexBarrelHits.position.y)*0.1:VertexBarrelHits.position.z*0.1>>hitsrz_vtx_si_1";
+
+    TString si_barrel_hitsrz_negR ="-1.0*sqrt(SiBarrelHits.position.x*SiBarrelHits.position.x+SiBarrelHits.position.y*SiBarrelHits.position.y)*0.1:SiBarrelHits.position.z*0.1>>hitsrz_barrel_si_1";
+
+    TString barrel_mpgd_in_hitsrz_negR= "-1.0*sqrt(MPGDBarrelHits.position.x*MPGDBarrelHits.position.x+MPGDBarrelHits.position.y*MPGDBarrelHits.position.y)*0.1:MPGDBarrelHits.position.z*0.1>>hitsrz_barrel_mm_in_1";
+
+    TString tof_barrel_hitsrz_negR ="-1.0*sqrt(TOFBarrelHits.position.x*TOFBarrelHits.position.x+TOFBarrelHits.position.y*TOFBarrelHits.position.y)*0.1:TOFBarrelHits.position.z*0.1>>hitsrz_barrel_tof_1";
+
+    TString barrel_mpgd_out_hitsrz_negR ="-1.0*sqrt(OuterMPGDBarrelHits.position.x*OuterMPGDBarrelHits.position.x+OuterMPGDBarrelHits.position.y*OuterMPGDBarrelHits.position.y)*0.1:OuterMPGDBarrelHits.position.z*0.1>>hitsrz_barrel_mm_out_1";
+
+    TString disks_si_hitsrz_negR ="-1.0*sqrt(TrackerEndcapHits.position.x*TrackerEndcapHits.position.x+TrackerEndcapHits.position.y*TrackerEndcapHits.position.y)*0.1:TrackerEndcapHits.position.z*0.1>>hitsrz_disks_si_1";
+
+    TString endcap_tof_hitsrz_negR ="-1.0*sqrt(TOFEndcapHits.position.x*TOFEndcapHits.position.x+TOFEndcapHits.position.y*TOFEndcapHits.position.y)*0.1:TOFEndcapHits.position.z*0.1>>hitsrz_endcap_tof_1";
+
+    TString fwd_mpgd_hitsrz_negR ="-1.0*sqrt(ForwardMPGDEndcapHits.position.x*ForwardMPGDEndcapHits.position.x+ForwardMPGDEndcapHits.position.y*ForwardMPGDEndcapHits.position.y)*0.1:ForwardMPGDEndcapHits.position.z*0.1>>hitsrz_fwd_mpgd_1";
+
+    TString bwd_mpgd_hitsrz_negR ="-1.0*sqrt(BackwardMPGDEndcapHits.position.x*BackwardMPGDEndcapHits.position.x+BackwardMPGDEndcapHits.position.y*BackwardMPGDEndcapHits.position.y)*0.1:BackwardMPGDEndcapHits.position.z*0.1>>hitsrz_bwd_mpgd_1";
+
+          sim->Draw(si_vtx_hitsrz_negR.Data(),"VertexBarrelHits.position.y<0",""); // Multiply by 0.1 for cm
+          sim->Draw(si_barrel_hitsrz_negR.Data(),"SiBarrelHits.position.y<0","");
+          sim->Draw(barrel_mpgd_in_hitsrz_negR.Data(),"MPGDBarrelHits.position.y<0","");
+          sim->Draw(tof_barrel_hitsrz_negR.Data(),"TOFBarrelHits.position.y<0","");
+          sim->Draw(disks_si_hitsrz_negR.Data(),"TrackerEndcapHits.position.y<0","");
+          sim->Draw(endcap_tof_hitsrz_negR.Data(),"TOFEndcapHits.position.y<0","");
+          sim->Draw(barrel_mpgd_out_hitsrz_negR.Data(),"OuterMPGDBarrelHits.position.y<0","");
+          sim->Draw(fwd_mpgd_hitsrz_negR.Data(),"ForwardMPGDEndcapHits.position.y<0","");
+          sim->Draw(bwd_mpgd_hitsrz_negR.Data(),"BackwardMPGDEndcapHits.position.y<0","");
+
+
+          hitsrz_vtx_si->SetMarkerStyle(31);
+          hitsrz_vtx_si->SetTitle("");
+          hitsrz_vtx_si->SetMarkerSize(0.1);
+          hitsrz_vtx_si->SetLineColor(kBlack);
+          hitsrz_vtx_si->SetMarkerColor(kBlack);
+          hitsrz_vtx_si->GetXaxis()->SetTitle("Z [cm]");
+          hitsrz_vtx_si->GetYaxis()->SetTitle("R [cm]");
+          hitsrz_vtx_si->GetXaxis()->CenterTitle();
+          hitsrz_vtx_si->GetYaxis()->CenterTitle();
+
+          hitsrz_vtx_si_1->SetMarkerSize(0.1);
+          hitsrz_vtx_si_1->SetLineColor(kBlack);
+          hitsrz_vtx_si_1->SetMarkerColor(kBlack);
+
+          hitsrz_barrel_si->SetMarkerStyle(20);
+          hitsrz_barrel_si->SetMarkerSize(0.1);
+          hitsrz_barrel_si->SetMarkerColor(kMagenta);
+          hitsrz_barrel_si->SetLineColor(kMagenta);
+
+          hitsrz_barrel_si_1->SetMarkerSize(0.1);
+          hitsrz_barrel_si_1->SetLineColor(kMagenta);
+          hitsrz_barrel_si_1->SetMarkerColor(kMagenta);
+
+          hitsrz_barrel_mm_in->SetMarkerStyle(20);
+          hitsrz_barrel_mm_in->SetMarkerSize(0.1);
+          hitsrz_barrel_mm_in->SetLineColor(kBlue);
+          hitsrz_barrel_mm_in->SetMarkerColor(kBlue);
+          hitsrz_barrel_mm_in_1->SetMarkerSize(0.1);
+          hitsrz_barrel_mm_in_1->SetLineColor(kBlue);
+          hitsrz_barrel_mm_in_1->SetMarkerColor(kBlue);
+
+          hitsrz_barrel_tof->SetMarkerStyle(20);
+          hitsrz_barrel_tof->SetMarkerSize(0.1);
+          hitsrz_barrel_tof->SetLineColor(kGreen);
+          hitsrz_barrel_tof->SetMarkerColor(kGreen);
+          hitsrz_barrel_tof_1->SetMarkerSize(0.1);
+          hitsrz_barrel_tof_1->SetLineColor(kGreen);
+          hitsrz_barrel_tof_1->SetMarkerColor(kGreen);
+
+
+          hitsrz_barrel_mm_out->SetMarkerStyle(20);
+          hitsrz_barrel_mm_out->SetMarkerSize(0.1);
+          hitsrz_barrel_mm_out->SetMarkerColor(kBlue-7);
+          hitsrz_barrel_mm_out->SetLineColor(kBlue-7);
+
+          hitsrz_barrel_mm_out_1->SetMarkerSize(0.1);
+          hitsrz_barrel_mm_out_1->SetLineColor(kBlue-7);
+          hitsrz_barrel_mm_out_1->SetMarkerColor(kBlue-7);
+          hitsrz_endcap_tof->SetMarkerStyle(20);
+          hitsrz_endcap_tof->SetMarkerSize(0.1);
+          hitsrz_endcap_tof->SetMarkerColor(kCyan);
+          hitsrz_endcap_tof->SetLineColor(kCyan);
+
+          hitsrz_endcap_tof_1->SetMarkerSize(0.1);
+          hitsrz_endcap_tof_1->SetLineColor(kCyan);
+          hitsrz_endcap_tof_1->SetMarkerColor(kCyan);
+
+          hitsrz_disks_si->SetMarkerStyle(20);
+          hitsrz_disks_si->SetMarkerSize(0.1);
+          hitsrz_disks_si->SetMarkerColor(kRed);
+          hitsrz_disks_si->SetLineColor(kRed);
+
+          hitsrz_disks_si_1->SetMarkerSize(0.1);
+          hitsrz_disks_si_1->SetLineColor(kRed);
+          hitsrz_disks_si_1->SetMarkerColor(kRed);
+
+          hitsrz_fwd_mpgd->SetMarkerSize(0.1);
+          hitsrz_fwd_mpgd->SetLineColor(kRed-7);
+          hitsrz_fwd_mpgd->SetMarkerColor(kRed-7);
+          hitsrz_fwd_mpgd_1->SetMarkerSize(0.1);
+          hitsrz_fwd_mpgd_1->SetLineColor(kRed-7);
+          hitsrz_fwd_mpgd_1->SetMarkerColor(kRed-7);
+          hitsrz_bwd_mpgd->SetMarkerSize(0.1);
+          hitsrz_bwd_mpgd->SetLineColor(kOrange);
+          hitsrz_bwd_mpgd->SetMarkerColor(kOrange);
+
+          hitsrz_bwd_mpgd_1->SetMarkerSize(0.1);
+          hitsrz_bwd_mpgd_1->SetLineColor(kOrange);
+          hitsrz_bwd_mpgd_1->SetMarkerColor(kOrange);
+
+        c2->cd();
+        hitsrz_vtx_si->Draw("");
+        hitsrz_vtx_si_1->Draw("same");
+        hitsrz_barrel_si->Draw("same");
+        hitsrz_barrel_si_1->Draw("same");
+        hitsrz_barrel_mm_in->Draw("same");
+        hitsrz_barrel_mm_in_1->Draw("same");
+        hitsrz_barrel_tof->Draw("same");
+        hitsrz_barrel_tof_1->Draw("same");
+        hitsrz_barrel_mm_out->Draw("same");
+        hitsrz_barrel_mm_out_1->Draw("same");
+        hitsrz_endcap_tof->Draw("same");
+        hitsrz_endcap_tof_1->Draw("same");
+        hitsrz_disks_si->Draw("same");
+        hitsrz_disks_si_1->Draw("same");
+        hitsrz_fwd_mpgd->Draw("same");
+        hitsrz_fwd_mpgd_1->Draw("same");
+        hitsrz_bwd_mpgd->Draw("same");
+        hitsrz_bwd_mpgd_1->Draw("same");
+
+  TLegend *l1= new TLegend(0.11,0.88,0.95,0.99);
+  l1->SetNColumns(3);
+  l1->SetTextSize(0.025);
+  l1->SetBorderSize(0);
+  l1->AddEntry(hitsrz_vtx_si,"VertexBarrelHits");
+  l1->AddEntry(hitsrz_barrel_si,"SiBarrelHits");
+  l1->AddEntry(hitsrz_barrel_mm_in,"MPGDBarrelHits");
+  l1->AddEntry(hitsrz_barrel_tof,"TOFBarrelHits");
+  l1->AddEntry(hitsrz_barrel_mm_out,"OuterMPGDBarrelHits");
+  l1->AddEntry(hitsrz_disks_si,"TrackerEndcapHits");
+  l1->AddEntry(hitsrz_endcap_tof,"TOFEndcapHits");
+  l1->AddEntry(hitsrz_fwd_mpgd,"ForwardMPGDEndcapHits");
+  l1->AddEntry(hitsrz_bwd_mpgd,"BackwardMPGDEndcapHits");
+  l1->Draw();
+
+  c2->SaveAs("hitsrz_dd4hep.png");
+  c2->SaveAs("hitsrz_dd4hep.eps");  
+  c2->SaveAs("hitsrz_dd4hep.root");
+ // Timer Stop
+  timer.Stop();
+  Double_t realtime = timer.RealTime();
+  Double_t cputime = timer.CpuTime();
+  printf("RealTime=%f seconds, CpuTime=%f seconds\n",realtime,cputime);
+
+}

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -82,11 +82,11 @@ void draw_hits(TString filename="", TString output_prefix=".")
         hitsxy_barrel_mm_out->SetLineColor(kBlue-7);
         
         c1->cd();
-        hitsxy_vtx_si->Draw();
-        hitsxy_barrel_si->Draw("same");
-        hitsxy_barrel_mm_in->Draw("same");
-        hitsxy_barrel_tof->Draw("same");
-        hitsxy_barrel_mm_out->Draw("same");
+        hitsxy_vtx_si->Draw("SCAT");
+        hitsxy_barrel_si->Draw("SCAT same");
+        hitsxy_barrel_mm_in->Draw("SCAT same");
+        hitsxy_barrel_tof->Draw("SCAT same");
+        hitsxy_barrel_mm_out->Draw("SCAT same");
 
  TLegend *l= new TLegend(0.65,0.85,0.90,1.0);
  l->SetTextSize(0.025);
@@ -267,24 +267,24 @@ void draw_hits(TString filename="", TString output_prefix=".")
           hitsrz_bwd_mpgd_1->SetMarkerColor(kOrange);
 
         c2->cd();
-        hitsrz_vtx_si->Draw("");
-        hitsrz_vtx_si_1->Draw("same");
-        hitsrz_barrel_si->Draw("same");
-        hitsrz_barrel_si_1->Draw("same");
-        hitsrz_barrel_mm_in->Draw("same");
-        hitsrz_barrel_mm_in_1->Draw("same");
-        hitsrz_barrel_tof->Draw("same");
-        hitsrz_barrel_tof_1->Draw("same");
-        hitsrz_barrel_mm_out->Draw("same");
-        hitsrz_barrel_mm_out_1->Draw("same");
-        hitsrz_endcap_tof->Draw("same");
-        hitsrz_endcap_tof_1->Draw("same");
-        hitsrz_disks_si->Draw("same");
-        hitsrz_disks_si_1->Draw("same");
-        hitsrz_fwd_mpgd->Draw("same");
-        hitsrz_fwd_mpgd_1->Draw("same");
-        hitsrz_bwd_mpgd->Draw("same");
-        hitsrz_bwd_mpgd_1->Draw("same");
+        hitsrz_vtx_si->Draw("SCAT");
+        hitsrz_vtx_si_1->Draw("SCAT same");
+        hitsrz_barrel_si->Draw("SCAT same");
+        hitsrz_barrel_si_1->Draw("SCAT same");
+        hitsrz_barrel_mm_in->Draw("SCAT same");
+        hitsrz_barrel_mm_in_1->Draw("SCAT same");
+        hitsrz_barrel_tof->Draw("SCAT same");
+        hitsrz_barrel_tof_1->Draw("SCAT same");
+        hitsrz_barrel_mm_out->Draw("SCAT same");
+        hitsrz_barrel_mm_out_1->Draw("SCAT same");
+        hitsrz_endcap_tof->Draw("SCAT same");
+        hitsrz_endcap_tof_1->Draw("SCAT same");
+        hitsrz_disks_si->Draw("SCAT same");
+        hitsrz_disks_si_1->Draw("SCAT same");
+        hitsrz_fwd_mpgd->Draw("SCAT same");
+        hitsrz_fwd_mpgd_1->Draw("SCAT same");
+        hitsrz_bwd_mpgd->Draw("SCAT same");
+        hitsrz_bwd_mpgd_1->Draw("SCAT same");
 
   TLegend *l1= new TLegend(0.11,0.88,0.95,0.99);
   l1->SetNColumns(3);

--- a/benchmarks/tracking_performances/draw_hits.C
+++ b/benchmarks/tracking_performances/draw_hits.C
@@ -13,7 +13,7 @@ void draw_hits(TString filename="", TString output_prefix=".")
 
 //==========Style of the plot============
    gStyle->SetPalette(1);
-   gStyle->SetOptTitle(1);
+   gStyle->SetOptTitle(0);
    gStyle->SetTitleOffset(.85,"X");gStyle->SetTitleOffset(.85,"Y");
    gStyle->SetTitleSize(.04,"X");gStyle->SetTitleSize(.04,"Y");
    gStyle->SetLabelSize(.04,"X");gStyle->SetLabelSize(.04,"Y");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This pull request includes the code that will run the simulation output EDM file at a given momentum and produce the hitmap XY and RZ for the ePIC tracker. Additional code generates the average Nhits vs Eta distribution for the ePIC tracker. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x ] Other: __
This will directly allow us to see the changes in the geometry as well as the average number of hits vs eta.

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x ] Changes have been communicated to collaborators
- The expected output is also attached with the ePIC 24.12.0, which I will present in the next tracking meeting.
- In the hit map (RZ), it can be seen inner MPGD geometry is changed as well as the inner radius of forward MPGD disks, ETOF is increased.

![Nhitsvsmom0 5](https://github.com/user-attachments/assets/140e8d85-3b58-4ea4-9460-9712bfeab8fd)
![Nhitsvsmom1 0](https://github.com/user-attachments/assets/0a7a8b2e-3cff-431e-a232-c2e148b674e3)
![Nhitsvsmom2 0](https://github.com/user-attachments/assets/db12a993-8e1b-4ef4-be3b-e83a50bfbfa2)
![Nhitsvsmom5 0](https://github.com/user-attachments/assets/887bbea2-c06b-49aa-8ddc-c2a1b2b1584e)
![Nhitsvsmom10 0](https://github.com/user-attachments/assets/a85fb302-40cf-465f-80ca-6dc67af50a4c)
![Nhitsvsmom15 0](https://github.com/user-attachments/assets/4f89d6b3-afeb-40ef-a017-25465df67e7b)
![hitsrz_dd4hep](https://github.com/user-attachments/assets/eef72f2d-752b-4656-b3b2-86b876032b37)
![hitsxy_dd4hep](https://github.com/user-attachments/assets/b0895bb3-20a6-42da-a44e-d4835ccc38f9)


### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No