### PR TITLE
bench:ecal_gaps:allow_failure: true

### DIFF
--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -16,6 +16,7 @@ bench:ecal_gaps:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/ecal_gaps/requirements.txt
     - snakemake $SNAKEMAKE_FLAGS --cores 8 results/epic_inner_detector/ecal_gaps
+  allow_failure: true
 
 collect_results:ecal_gaps:
   extends: .det_benchmark


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`bench:ecal_gaps` is failing more often than acceptable, for reasons unrelated to the job. This PR allows the benchmarks to fail.