### PR TITLE
Syntax fixes

### DIFF
--- a/benchmarks/backwards_ecal/Snakefile
+++ b/benchmarks/backwards_ecal/Snakefile
@@ -18,7 +18,7 @@ rule backwards_ecal_sim:
         PARTICLE="(e-|pi-)",
         ENERGY="[0-9]+[kMG]eV",
         PHASE_SPACE="(3to50|45to135|130to177)deg",
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         N_EVENTS=get_n_events,
         SEED=lambda wildcards: "1" + wildcards.INDEX,
@@ -51,7 +51,7 @@ rule backwards_ecal_recon:
     log:
         "sim_output/backwards_ecal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,
         EICRECON_HASH=get_spack_package_hash("eicrecon"),

--- a/benchmarks/calo_pid/Snakefile
+++ b/benchmarks/calo_pid/Snakefile
@@ -15,7 +15,7 @@ rule calo_pid_sim:
         ENERGY_MAX="[0-9]+[kMG]eV",
         THETA_MIN="[0-9]+",
         THETA_MAX="[0-9]+",
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         N_EVENTS=1000,
         SEED=lambda wildcards: "1" + wildcards.INDEX,
@@ -55,7 +55,7 @@ rule calo_pid_recon:
     log:
         "sim_output/calo_pid/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     shell: """
 set -m # monitor mode to prevent lingering processes
 exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -14,7 +14,7 @@ rule ecal_gaps_sim:
         PARTICLE="e-",
         ENERGY="(500MeV|5GeV|20GeV)",
         PHASE_SPACE="(3to50|45to135|130to177)deg",
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         N_EVENTS=1000,
         SEED=lambda wildcards: "1" + wildcards.INDEX,
@@ -47,7 +47,7 @@ rule ecal_gaps_recon:
     log:
         "sim_output/ecal_gaps/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,
         EICRECON_HASH=get_spack_package_hash("eicrecon"),

--- a/benchmarks/lfhcal/Snakefile
+++ b/benchmarks/lfhcal/Snakefile
@@ -17,7 +17,7 @@ rule lfhcal_sim:
         ENERGY="[0-9]+[kMG]eV",
         PARTICLE="(neutron|pi-|gamma)",
         PHASE_SPACE="3to50deg",
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         N_EVENTS=get_n_events,
     shell:
@@ -43,7 +43,7 @@ rule lfhcal_recon:
     log:
         "sim_output/lfhcal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     shell: """
 env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
   eicrecon {input} -Ppodio:output_file={output} \

--- a/benchmarks/lfhcal/Snakefile
+++ b/benchmarks/lfhcal/Snakefile
@@ -93,7 +93,7 @@ rule lfhcal_summary_at_eta:
         "{CAMPAIGN}/Final_Results/{PARTICLE}/mom/lfhcal_mom_resol_{PARTICLE}_{ETA_MIN}_eta_{ETA_MAX}.png",
         "{CAMPAIGN}/Final_Results/{PARTICLE}/mom/lfhcal_mom_resol_{PARTICLE}_{ETA_MIN}_eta_{ETA_MAX}.root",
     shell:
-        """
+        r"""
 if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
         set +e
         EPIC_VERSION="${{DETECTOR_VERSION:-}}"

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -139,7 +139,7 @@ rule tracking_performance_summary_at_eta:
         "{CAMPAIGN}/Final_Results/pi-/dca/dcaz_resol_{ETA_MIN}_eta_{ETA_MAX}.png", 
         "{CAMPAIGN}/Final_Results/pi-/dca/dcaz_resol_{ETA_MIN}_eta_{ETA_MAX}.root",    
     shell:
-        """
+        r"""
 if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
         set +e
         EPIC_VERSION="${{DETECTOR_VERSION:-}}"

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -10,7 +10,7 @@ rule tracking_performance_sim:
         PARTICLE="pi-",
         ENERGY="[0-9]+[kMG]eV",
         PHASE_SPACE="(3to50|45to135|130to177)deg",
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     params:
         N_EVENTS=10000
     shell:
@@ -37,7 +37,7 @@ rule tracking_performance_recon:
     log:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
-        INDEX="\d{4}",
+        INDEX=r"\d{4}",
     shell: """
 set -m # monitor mode to prevent lingering processes
 exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -69,10 +69,10 @@ rule dis_analysis:
         hists_vtx="results/vertexing_performances_dis/{DETECTOR_CONFIG}/{PREFIX}pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_{INDEX}/hists.root",
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
-        INDEX="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
+        INDEX=r"\d+",
     shell:
         """
 cat > {output.config_trk} <<EOF
@@ -112,10 +112,10 @@ rule dis_combine:
         hists_vtx="results/vertexing_performances_dis/{DETECTOR_CONFIG}/{PREFIX}pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_combined_{NUM_FILES}/hists.root",
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
-        NUM_FILES="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
+        NUM_FILES=r"\d+",
     shell:
         """
 cat > {output.config_trk} <<EOF
@@ -155,10 +155,10 @@ rule trk_dis_plots:
         "results/tracking_performances_dis/{DETECTOR_CONFIG}/{PREFIX}pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_combined_{NUM_FILES}/plots.pdf"
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
-        NUM_FILES="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
+        NUM_FILES=r"\d+",
     shell:
         """
 root -l -b -q '{input.script}+("{input.config}")'
@@ -173,10 +173,10 @@ rule vtx_dis_plots:
         "results/vertexing_performances_dis/{DETECTOR_CONFIG}/{PREFIX}pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_combined_{NUM_FILES}/plots.pdf"
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
-        NUM_FILES="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
+        NUM_FILES=r"\d+",
     shell:
         """
 root -l -b -q '{input.script}+("{input.config}")'

--- a/benchmarks/zdc_lyso/Snakefile
+++ b/benchmarks/zdc_lyso/Snakefile
@@ -58,7 +58,7 @@ rule zdc_lyso_analysis:
                PARTICLE=["gamma"],
                BEAM_ENERGY=["0.005", "0.01", "0.05", "0.1", "0.5", "1.0"],
                THETA_MIN=["0"],
-               THETA_MAX=["0.3"]),        
+               THETA_MAX=["0.3"]),
         script="benchmarks/zdc_lyso/analysis/analysis.py",
     output:
         "results/{DETECTOR_CONFIG}/zdc_lyso/plots.pdf",


### PR DESCRIPTION
Recent versions of Snakemake are stricter about tab/space mixing and are more eager to show syntax warnings. This addresses the issues that will pop up.