### PR TITLE
benchmarks/{background,ecal_gaps}/Snakefile: redirect dask scheduler/worker to .logs

### DIFF
--- a/benchmarks/backgrounds/Snakefile
+++ b/benchmarks/backgrounds/Snakefile
@@ -38,6 +38,9 @@ rule backgrounds_ecal_backwards:
         proton_beam_gas_sim="sim_output/" + DETECTOR_CONFIG + "/backgrounds/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/proton/pythia8.306-1.0/100GeV/pythia8.306-1.0_ProtonBeamGas_100GeV_run001.edm4hep.root",
     output:
         directory("results/backgrounds/backwards_ecal")
+    log:
+        scheduler=".logs/results/backgrounds/backwards_ecal/scheduler.log",
+        worker=".logs/results/backgrounds/backwards_ecal/worker.log",
     threads: workflow.cores
     shell:
         """
@@ -49,10 +52,10 @@ cleanup() {{
 trap cleanup EXIT
 
 PORT=$RANDOM
-dask scheduler --port $PORT &
+dask scheduler --port $PORT 2>{log.scheduler} &
 export DASK_SCHEDULER=localhost:$PORT
 SCHEDULER_PID=$!
-dask worker tcp://$DASK_SCHEDULER --nworkers {threads} --nthreads 1 &
+dask worker tcp://$DASK_SCHEDULER --nworkers {threads} --nthreads 1 2>{log.worker} &
 WORKER_PID=$!
 env \
 MATPLOTLIBRC={input.matplotlibrc} \

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -74,6 +74,9 @@ rule ecal_gaps:
         ),
     output:
         directory("results/{DETECTOR_CONFIG}/ecal_gaps"),
+    log:
+        scheduler=".logs/results/{DETECTOR_CONFIG}/ecal_gaps/scheduler.log",
+        worker=".logs/results/{DETECTOR_CONFIG}/ecal_gaps/worker.log",
     threads: workflow.cores
     shell:
         """
@@ -85,10 +88,10 @@ cleanup() {{
 trap cleanup EXIT
 
 PORT=$RANDOM
-dask scheduler --port $PORT &
+dask scheduler --port $PORT 2>{log.scheduler} &
 export DASK_SCHEDULER=localhost:$PORT
 SCHEDULER_PID=$!
-dask worker tcp://$DASK_SCHEDULER --nworkers {threads} --nthreads 1 &
+dask worker tcp://$DASK_SCHEDULER --nworkers {threads} --nthreads 1 2>{log.worker} &
 WORKER_PID=$!
 env \
 MATPLOTLIBRC={input.matplotlibrc} \


### PR DESCRIPTION
dask produces lots of output which we don't care about, but that obstructs legitimate errors from the becnhmark

cc #115