### PR TITLE
fix: use shell to write .matplotlibrc

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -101,11 +101,14 @@ exec ddsim \
 rule matplotlibrc:
     output:
         ".matplotlibrc",
-    run:
-        with open(output[0], "wt") as fp:
-            fp.write("backend: Agg\n")
-            # interactive mode prevents plt.show() from blocking
-            fp.write("interactive : True\n")
+    shell:
+        """
+cat > {output} <<EOF
+backend: Agg
+# interactive mode prevents plt.show() from blocking
+interactive: True
+EOF
+"""
 
 
 rule org2py:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This changes a problematic rule from python to shell. Same functionality (comment on interactivity retained in file instead of code comment).

[Underlying issue](https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/4393948#L825) not really understood, but this gets the failing pipelines unstuck in local testing with that pipeline's container.