### PR TITLE
backgrounds,backwards_ecal: pin packages to compatible versions

### DIFF
--- a/benchmarks/backgrounds/requirements.txt
+++ b/benchmarks/backgrounds/requirements.txt
@@ -1,7 +1,7 @@
-awkward >= 2.4.0
-dask >= 2023
-dask_awkward
-dask_histogram
-distributed >= 2023
+awkward ~= 2.7.2
+dask ~= 2024.12.1
+dask_awkward ~= 2024.12.2
+dask_histogram ~= 2024.12.1
+distributed ~= 2024.12.1
 pyhepmc
-uproot >= 5.2.0
+uproot ~= 5.5.1

--- a/benchmarks/backwards_ecal/requirements.txt
+++ b/benchmarks/backwards_ecal/requirements.txt
@@ -1,8 +1,8 @@
-awkward >= 2.4.0
-boost_histogram
-dask >= 2024
-dask_awkward >= 2024
-dask_histogram
-distributed >= 2024
-uproot >= 5.2.0
-vector
+awkward ~= 2.7.2
+dask ~= 2024.12.1
+dask_awkward ~= 2024.12.2
+dask_histogram ~= 2024.12.1
+distributed ~= 2024.12.1
+pyhepmc
+uproot ~= 5.5.1
+vector ~= 1.5.2


### PR DESCRIPTION
We get errors:
```
  File "/opt/local/lib/python3.11/site-packages/dask_histogram/__init__.py", line 6, in <module>
    from dask_histogram.core import (
  File "/opt/local/lib/python3.11/site-packages/dask_histogram/core.py", line 22, in <module>
    from dask_histogram.layers import MockableDataFrameTreeReduction
  File "/opt/local/lib/python3.11/site-packages/dask_histogram/layers.py", line 1, in <module>
    from dask.layers import DataFrameTreeReduction
ImportError: cannot import name 'DataFrameTreeReduction' from 'dask.layers' (/opt/local/lib/python3.11/site-packages/dask/layers.py)
```
Also, `dask` >= 2023 is satisfied by our current spack, but `distributed` is not provided and is out of sync as the result.