### PR TITLE
{tracking,vertexing}_performances_dis: name png files after benchmark

### DIFF
--- a/benchmarks/tracking_performances_dis/config.yml
+++ b/benchmarks/tracking_performances_dis/config.yml
@@ -34,10 +34,10 @@ collect_results:tracking_performances_dis:
     # convert to png
     - |
       gs -sDEVICE=pngalpha -dUseCropBox -r144 \
-        -o 'results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plot_%03d.png' \
+        -o 'results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/tracking_performances_dis_%03d.png' \
         results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plots.pdf
     - |
       gs -sDEVICE=pngalpha -dUseCropBox -r144 \
-        -o 'results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plot_%03d.png' \
+        -o 'results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/tracking_performances_dis_%03d.png' \
         results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plots.pdf
         

--- a/benchmarks/tracking_performances_dis/config.yml
+++ b/benchmarks/tracking_performances_dis/config.yml
@@ -38,6 +38,6 @@ collect_results:tracking_performances_dis:
         results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plots.pdf
     - |
       gs -sDEVICE=pngalpha -dUseCropBox -r144 \
-        -o 'results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/tracking_performances_dis_%03d.png' \
+        -o 'results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/vertexing_performances_dis_%03d.png' \
         results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plots.pdf
         


### PR DESCRIPTION
This is needed to produce clearer plot names in image_viewer https://eic.jlab.org/epic/image_browser.html#
Ideally we don't just number those, but give them readable names.

This also avoids the naming confusion between tracking and vertexing.