### PR TITLE
fix: avoid warning in backwards_ecal with fr-string

### DIFF
--- a/benchmarks/backwards_ecal/backwards_ecal.org
+++ b/benchmarks/backwards_ecal/backwards_ecal.org
@@ -255,7 +255,7 @@ for clf_label, sigma_rel_FWHM_cb in sigmas_rel_FWHM_cb.items():
         f(xs, *par),
         ls="--",
         lw=0.5,
-        label=f"Functional fit: ${np.ceil(stochastic * 10) / 10:.1f}\% / \sqrt{{E}} \oplus {np.ceil(constant * 10) / 10:.1f}\%$",
+        label=fr"Functional fit: ${np.ceil(stochastic * 10) / 10:.1f}\% / \sqrt{{E}} \oplus {np.ceil(constant * 10) / 10:.1f}\%$",
     )
 xmin = np.min(energy_values)
 xmax = np.max(energy_values) * 1.05


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This avoids https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/4661855#L5496.

FYI, https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals