### PR TITLE
ZDC benchmarks use reconstructed particles from EICrecon, rather than attempting to reconstruct them directly

### DIFF
--- a/benchmarks/zdc_lambda/Snakefile
+++ b/benchmarks/zdc_lambda/Snakefile
@@ -14,7 +14,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},0,"{output.GEN_FILE}",{params.P}
 rule zdc_lambda_simulate:
         input:
                 GEN_FILE="sim_output/zdc_lambda/lambda_decay_{P}GeV.hepmc",
-                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+#                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
                 geometry_lib=find_epic_libraries(),
         output:
                 SIM_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV_{INDEX}.edm4hep.root",
@@ -52,7 +52,7 @@ rule zdc_lambda_recon:
         shell:
                 """
 env DETECTOR_CONFIG={params.DETECTOR_CONFIG} \
-  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits -Pjana:nevents={params.N_EVENTS}
+  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits,ReconstructedFarForwardZDCLambdas,ReconstructedFarForwardZDCLambdaDecayProducts -Pjana:nevents={params.N_EVENTS}
 """
 
 rule zdc_lambda_analysis:

--- a/benchmarks/zdc_lambda/Snakefile
+++ b/benchmarks/zdc_lambda/Snakefile
@@ -14,7 +14,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},0,"{output.GEN_FILE}",{params.P}
 rule zdc_lambda_simulate:
         input:
                 GEN_FILE="sim_output/zdc_lambda/lambda_decay_{P}GeV.hepmc",
-#                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
                 geometry_lib=find_epic_libraries(),
         output:
                 SIM_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV_{INDEX}.edm4hep.root",

--- a/benchmarks/zdc_lambda/Snakefile
+++ b/benchmarks/zdc_lambda/Snakefile
@@ -52,7 +52,7 @@ rule zdc_lambda_recon:
         shell:
                 """
 env DETECTOR_CONFIG={params.DETECTOR_CONFIG} \
-  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits,ReconstructedFarForwardZDCLambdas,ReconstructedFarForwardZDCLambdaDecayProducts -Pjana:nevents={params.N_EVENTS}
+  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits,ReconstructedFarForwardZDCLambdaAndDecayProducts -Pjana:nevents={params.N_EVENTS}
 """
 
 rule zdc_lambda_analysis:

--- a/benchmarks/zdc_lambda/Snakefile
+++ b/benchmarks/zdc_lambda/Snakefile
@@ -52,7 +52,7 @@ rule zdc_lambda_recon:
         shell:
                 """
 env DETECTOR_CONFIG={params.DETECTOR_CONFIG} \
-  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits,ReconstructedFarForwardZDCLambdaAndDecayProducts -Pjana:nevents={params.N_EVENTS}
+  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits,ReconstructedFarForwardZDCLambdas,ReconstructedFarForwardZDCLambdaDecayProductsCM -Pjana:nevents={params.N_EVENTS}
 """
 
 rule zdc_lambda_analysis:

--- a/benchmarks/zdc_lambda/analysis/lambda_plots.py
+++ b/benchmarks/zdc_lambda/analysis/lambda_plots.py
@@ -64,11 +64,11 @@ zvtx_recon={}
 mass_recon={}
 print(arrays_sim[p].fields)
 for p in momenta:
-    isLambda=arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.PDG"]==3122
-    px,py,pz,m=(arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.{a}"][isLambda] for a in "momentum.x momentum.y momentum.z mass".split())
+
+    px,py,pz,m=(arrays_sim[p][f"ReconstructedFarForwardZDCLambdas.{a}"] for a in "momentum.x momentum.y momentum.z mass".split())
     theta_recon[p]=np.arctan2(np.hypot(px*np.cos(tilt)-pz*np.sin(tilt), py),pz*np.cos(tilt)+px*np.sin(tilt))
     E_recon[p]=np.sqrt(px**2+py**2+pz**2+m**2)
-    zvtx_recon[p]=(arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.referencePoint.z"]*np.cos(tilt)+arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.referencePoint.x"]*np.sin(tilt))[isLambda]
+    zvtx_recon[p]=arrays_sim[p][f"ReconstructedFarForwardZDCLambdas.referencePoint.z"]*np.cos(tilt)+arrays_sim[p][f"ReconstructedFarForwardZDCLambdas.referencePoint.x"]*np.sin(tilt)
     mass_recon[p]=m
 
 #theta plots

--- a/benchmarks/zdc_lambda/analysis/lambda_plots.py
+++ b/benchmarks/zdc_lambda/analysis/lambda_plots.py
@@ -115,7 +115,6 @@ for p in momenta:
     slc=abs(bc)<0.3
     fnc=gauss
     p0=(100, 0, 0.06)
-    #print(bc[slc],y[slc])
     sigma=np.sqrt(y[slc])+(y[slc]==0)
     try:
         coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0, sigma=list(sigma), maxfev=10000)

--- a/benchmarks/zdc_lambda/analysis/lambda_plots.py
+++ b/benchmarks/zdc_lambda/analysis/lambda_plots.py
@@ -64,11 +64,14 @@ zvtx_recon={}
 mass_recon={}
 print(arrays_sim[p].fields)
 for p in momenta:
-    px,py,pz,m=(arrays_sim[p][f"ReconstructedFarForwardZDCLambdas.{a}"] for a in "momentum.x momentum.y momentum.z mass".split())
+    isLambda=arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.PDG"]==3122
+    px,py,pz,m=(arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.{a}"][isLambda] for a in "momentum.x momentum.y momentum.z mass".split())
     theta_recon[p]=np.arctan2(np.hypot(px*np.cos(tilt)-pz*np.sin(tilt), py),pz*np.cos(tilt)+px*np.sin(tilt))
     E_recon[p]=np.sqrt(px**2+py**2+pz**2+m**2)
-    zvtx_recon[p]=arrays_sim[p][f"ReconstructedFarForwardZDCLambdas.referencePoint.z"]*np.cos(tilt)+arrays_sim[p][f"ReconstructedFarForwardZDCLambdas.referencePoint.x"]*np.sin(tilt)
+    zvtx_recon[p]=(arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.referencePoint.z"]*np.cos(tilt)+arrays_sim[p][f"ReconstructedFarForwardZDCLambdaAndDecayProducts.referencePoint.x"]*np.sin(tilt))[isLambda]
     mass_recon[p]=m
+
+#theta plots
 fig,axs=plt.subplots(1,3, figsize=(24, 8))
 plt.sca(axs[0])
 plt.title(f"$E_{{\\Lambda}}=100-275$ GeV")
@@ -76,7 +79,7 @@ x=[]
 y=[]
 import awkward as ak
 for p in momenta:
-    x+=list(theta_truth[p][np.sum(theta_recon[p]**0,axis=-1)>0]*1000)
+    x+=list(ak.flatten(theta_truth[p]+0*theta_recon[p])*1000)
     y+=list(ak.flatten(theta_recon[p]*1000))
 plt.scatter(x,y)
 plt.xlabel("$\\theta^{*\\rm truth}_{\\Lambda}$ [mrad]")
@@ -133,14 +136,14 @@ plt.tight_layout()
 plt.savefig(outdir+"thetastar_recon.pdf")
 #plt.show()
 
-
+#vtx z
 fig,axs=plt.subplots(1,3, figsize=(24, 8))
 plt.sca(axs[0])
 plt.title(f"$E_{{\\Lambda}}=100-275$ GeV")
 x=[]
 y=[]
 for p in momenta:
-    x+=list(arrays_sim[p]['MCParticles.vertex.z'][:,3][np.sum(zvtx_recon[p]**0, axis=-1)!=0]/1000)
+    x+=list(ak.flatten(arrays_sim[p]['MCParticles.vertex.z'][:,3]+0*zvtx_recon[p])/1000)
     y+=list(ak.flatten(zvtx_recon[p])/1000)
 plt.scatter(x,y)
 #print(x,y)

--- a/benchmarks/zdc_lambda/analysis/lambda_plots.py
+++ b/benchmarks/zdc_lambda/analysis/lambda_plots.py
@@ -224,7 +224,7 @@ plt.ylim(0, np.max(y)*1.2)
 plt.xlim(1.0, 1.25)
 
 from scipy.optimize import curve_fit
-slc=abs(bc-lambda_mass)<0.07
+slc=abs(bc-lambda_mass)<0.05
 fnc=gauss
 p0=[100, lambda_mass, 0.04]
 coeff, var_matrix = curve_fit(fnc, bc[slc], y[slc], p0=p0,
@@ -245,7 +245,7 @@ for p in momenta:
     bc=(x[1:]+x[:-1])/2
 
     from scipy.optimize import curve_fit
-    slc=abs(bc-lambda_mass)<0.07
+    slc=abs(bc-lambda_mass)<0.05
     fnc=gauss
     p0=[100, lambda_mass, 0.05]
     try:

--- a/benchmarks/zdc_neutron/Snakefile
+++ b/benchmarks/zdc_neutron/Snakefile
@@ -44,7 +44,7 @@ rule zdc_neutron_reco:
 set -m # monitor mode to prevent lingering processes
 exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
   eicrecon {input} -Ppodio:output_file={output} \
-  -Ppodio:output_collections=MCParticles,EcalFarForwardZDCRawHits,EcalFarForwardZDCRecHits,EcalFarForwardZDCClusters,HcalFarForwardZDCRawHits,HcalFarForwardZDCRecHits,HcalFarForwardZDCClusters,ReconstructedFarForwardZDCNeutrons
+  -Ppodio:output_collections=MCParticles,EcalFarForwardZDCRawHits,EcalFarForwardZDCRecHits,EcalFarForwardZDCClusters,HcalFarForwardZDCRawHits,HcalFarForwardZDCRecHits,HcalFarForwardZDCClusters,ReconstructedFarForwardZDCNeutrals
 """
 
 

--- a/benchmarks/zdc_neutron/analysis/fwd_neutrons_recon.C
+++ b/benchmarks/zdc_neutron/analysis/fwd_neutrons_recon.C
@@ -112,11 +112,11 @@ void fwd_neutrons_recon(std::string inputfile, std::string outputfile){
     TTreeReaderArray<float> hcal_cluster_energy(tr, "HcalFarForwardZDCClusters.energy");
     
     //Reconstructed neutron quantity
-    TTreeReaderArray<float> rec_neutron_energy(tr,"ReconstructedFarForwardZDCNeutrons.energy");
-    TTreeReaderArray<float> rec_neutron_px(tr,"ReconstructedFarForwardZDCNeutrons.momentum.x");
-    TTreeReaderArray<float> rec_neutron_py(tr,"ReconstructedFarForwardZDCNeutrons.momentum.y");
-    TTreeReaderArray<float> rec_neutron_pz(tr,"ReconstructedFarForwardZDCNeutrons.momentum.z");
-
+    TTreeReaderArray<float> rec_neutron_energy(tr,"ReconstructedFarForwardZDCNeutrals.energy");
+    TTreeReaderArray<float> rec_neutron_px(tr,"ReconstructedFarForwardZDCNeutrals.momentum.x");
+    TTreeReaderArray<float> rec_neutron_py(tr,"ReconstructedFarForwardZDCNeutrals.momentum.y");
+    TTreeReaderArray<float> rec_neutron_pz(tr,"ReconstructedFarForwardZDCNeutrals.momentum.z");
+    TTreeReaderArray<int> rec_neutron_PDG(tr,"ReconstructedFarForwardZDCNeutrals.PDG");
     //Other variables
     int counter(0);
     
@@ -195,6 +195,8 @@ void fwd_neutrons_recon(std::string inputfile, std::string outputfile){
 
        //Reconstructed neutron(s)
        for(int irec=0;irec<rec_neutron_energy.GetSize();irec++){
+	 if (rec_neutron_PDG[irec] != 2112)
+	   continue;
                 if(neut_true_rot.Theta()*1000. < 3.5 && hcal_clus_size==1){
                         h1_neut_rec->Fill(rec_neutron_energy[irec]);
 

--- a/benchmarks/zdc_photon/Snakefile
+++ b/benchmarks/zdc_photon/Snakefile
@@ -55,7 +55,7 @@ rule zdc_photon_recon:
         shell:
                 """
 env DETECTOR_CONFIG={params.DETECTOR_CONFIG} \
-  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCRecHits,HcalFarForwardZDCClusters,HcalFarForwardZDCSubcellHits -Pjana:nevents={params.N_EVENTS}
+  eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Ppodio:output_collections=MCParticles,HcalFarForwardZDCRecHits,HcalFarForwardZDCClusters,HcalFarForwardZDCSubcellHits,ReconstructedFarForwardZDCNeutrals -Pjana:nevents={params.N_EVENTS}
 """
 
 rule zdc_photon_analysis:

--- a/benchmarks/zdc_photon/analysis/zdc_photon_plots.py
+++ b/benchmarks/zdc_photon/analysis/zdc_photon_plots.py
@@ -27,7 +27,7 @@ for p in momenta:
         f'sim_output/zdc_photon/{config}_rec_zdc_photon_{p}GeV_{index}.edm4eic.root': 'events'
         for index in range(5)
     })
-
+import awkward as ak
 fig,axs=plt.subplots(1,3, figsize=(24, 8))
 pvals=[]
 resvals=[]
@@ -35,20 +35,16 @@ dresvals=[]
 scalevals=[]
 dscalevals=[]
 for p in momenta:
-    selection=[len(arrays_sim[p]["HcalFarForwardZDCClusters.energy"][i])==1 for i in range(len(arrays_sim[p]))]
-    E=arrays_sim[p][selection]["HcalFarForwardZDCClusters.energy"]
-    
-    Etot=np.sum(E, axis=-1)
-    #print(len(Etot))
-    #print(p, res, mrecon)
+    selection=arrays_sim[p]["ReconstructedFarForwardZDCNeutrals.PDG"]==22
+    Etot=arrays_sim[p]["ReconstructedFarForwardZDCNeutrals.energy"][selection]
     if p==100:
         plt.sca(axs[0])
-        y, x, _=plt.hist(Etot, bins=100, range=(p*.75, p*1.25), histtype='step')
+        y, x, _=plt.hist(ak.flatten(Etot), bins=100, range=(p*.75, p*1.25), histtype='step')
         plt.ylabel("events")
-        plt.title(f"$p_{{\gamma}}$={p} GeV")
+        plt.title(f"$p_{{\\gamma}}$={p} GeV")
         plt.xlabel("$E^{\\gamma}_{recon}$ [GeV]")
     else:
-        y, x = np.histogram(Etot, bins=100, range=(p*.75, p*1.25))
+        y, x = np.histogram(ak.flatten(Etot), bins=100, range=(p*.75, p*1.25))
         
     bc=(x[1:]+x[:-1])/2
     from scipy.optimize import curve_fit
@@ -98,29 +94,28 @@ pvals=[]
 resvals=[]
 dresvals=[]
 for p in momenta:
-    selection=[len(arrays_sim[p]["HcalFarForwardZDCClusters.energy"][i])==1 for i in range(len(arrays_sim[p]))]
-    x=arrays_sim[p][selection]["HcalFarForwardZDCClusters.position.x"][::,0]
-    y=arrays_sim[p][selection]["HcalFarForwardZDCClusters.position.y"][::,0]
-    z=arrays_sim[p][selection]["HcalFarForwardZDCClusters.position.z"][::,0]
+    selection=arrays_sim[p]["ReconstructedFarForwardZDCNeutrals.PDG"]==22
+    px_recon=arrays_sim[p]["ReconstructedFarForwardZDCNeutrals.momentum.x"][selection]
+    py_recon=arrays_sim[p]["ReconstructedFarForwardZDCNeutrals.momentum.y"][selection]
+    pz_recon=arrays_sim[p]["ReconstructedFarForwardZDCNeutrals.momentum.z"][selection]
     
-    theta_recon=np.arctan2(np.hypot(x*np.cos(-.025)-z*np.sin(-.025), y), z*np.cos(-.025)+x*np.sin(-.025))
+    theta_recon=np.arctan2(np.hypot(px_recon*np.cos(-.025)-pz_recon*np.sin(-.025), py_recon), pz_recon*np.cos(-.025)+px_recon*np.sin(-.025))
     
-    px=arrays_sim[p][selection]["MCParticles.momentum.x"][::,2]
-    py=arrays_sim[p][selection]["MCParticles.momentum.y"][::,2]
-    pz=arrays_sim[p][selection]["MCParticles.momentum.z"][::,2]
+    px=arrays_sim[p]["MCParticles.momentum.x"][::,2]
+    py=arrays_sim[p]["MCParticles.momentum.y"][::,2]
+    pz=arrays_sim[p]["MCParticles.momentum.z"][::,2]
 
     theta_truth=np.arctan2(np.hypot(px*np.cos(-.025)-pz*np.sin(-.025), py), pz*np.cos(-.025)+px*np.sin(-.025))
     
-    Etot=np.sum(E, axis=-1)
     #print(p, res, mrecon)
     if p==100:
         plt.sca(axs[0])
-        y, x, _=plt.hist(1000*(theta_recon-theta_truth), bins=100, range=(-0.5, 0.5), histtype='step')
+        y, x, _=plt.hist(1000*ak.flatten(theta_recon-theta_truth), bins=100, range=(-0.5, 0.5), histtype='step')
         plt.ylabel("events")
-        plt.title(f"$p_{{\gamma}}$={p} GeV")
+        plt.title(f"$p_{{\\gamma}}$={p} GeV")
         plt.xlabel("$\\theta^{\\gamma}_{recon}$ [mrad]")
     else:
-        y, x = np.histogram(1000*(theta_recon-theta_truth), bins=100, range=(-0.5, 0.5))
+        y, x = np.histogram(1000*ak.flatten(theta_recon-theta_truth), bins=100, range=(-0.5, 0.5))
         
     bc=(x[1:]+x[:-1])/2
     from scipy.optimize import curve_fit
@@ -128,14 +123,17 @@ for p in momenta:
     fnc=gauss
     p0=[100, 0, 0.1]
     #print(list(y), list(x))
-    coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0,
+    try:
+        coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0,
                                  sigma=list(np.sqrt(y[slc])+(y[slc]==0)), maxfev=10000)
-    if p==100:
-        xx=np.linspace(-0.5,0.5, 100)
-        plt.plot(xx, fnc(xx,*coeff))
-    pvals.append(p)
-    resvals.append(np.abs(coeff[2]))
-    dresvals.append(np.sqrt(var_matrix[2][2]))
+        if p==100:
+            xx=np.linspace(-0.5,0.5, 100)
+            plt.plot(xx, fnc(xx,*coeff))
+        pvals.append(p)
+        resvals.append(np.abs(coeff[2]))
+        dresvals.append(np.sqrt(var_matrix[2][2]))
+    except:
+        pass
 plt.sca(axs[1])
 plt.errorbar(pvals, resvals, dresvals, ls='', marker='o')
 #print(dresvals)

--- a/benchmarks/zdc_photon/analysis/zdc_photon_plots.py
+++ b/benchmarks/zdc_photon/analysis/zdc_photon_plots.py
@@ -51,7 +51,6 @@ for p in momenta:
     slc=abs(bc-p)<10
     fnc=gauss
     p0=[100, p, 10]
-    #print(list(y), list(x))
     coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0,
                                  sigma=list(np.sqrt(y[slc])+(y[slc]==0)), maxfev=10000)
     if p==100:
@@ -106,8 +105,6 @@ for p in momenta:
     pz=arrays_sim[p]["MCParticles.momentum.z"][::,2]
 
     theta_truth=np.arctan2(np.hypot(px*np.cos(-.025)-pz*np.sin(-.025), py), pz*np.cos(-.025)+px*np.sin(-.025))
-    
-    #print(p, res, mrecon)
     if p==100:
         plt.sca(axs[0])
         y, x, _=plt.hist(1000*ak.flatten(theta_recon-theta_truth), bins=100, range=(-0.5, 0.5), histtype='step')
@@ -122,7 +119,6 @@ for p in momenta:
     slc=abs(bc)<0.2#1.5*np.std(1000*(theta_recon-theta_truth))
     fnc=gauss
     p0=[100, 0, 0.1]
-    #print(list(y), list(x))
     try:
         coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0,
                                  sigma=list(np.sqrt(y[slc])+(y[slc]==0)), maxfev=10000)
@@ -136,7 +132,6 @@ for p in momenta:
         pass
 plt.sca(axs[1])
 plt.errorbar(pvals, resvals, dresvals, ls='', marker='o')
-#print(dresvals)
 
 fnc=lambda E,a, b: np.hypot(a/np.sqrt(E), b)
 #pvals, resvals, dresvals


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Makes the benchmarks for the ZDC lambdas, photons, and neutrons use the reconstructed particles from EICrecon (see https://github.com/eic/EICrecon/pull/1731 ), rather than reconstructing them in the analysis code of the benchmarks.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Yes.  