### PR TITLE
fix: /work/eic2 -> /volatile/eic

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -60,7 +60,7 @@ def get_remote_path(path):
     if use_s3:
         return f"s3https://eics3.sdcc.bnl.gov:9000/eictest/{path}"
     elif use_xrootd:
-        return f"root://dtn-eic.jlab.org//work/eic2/{path}"
+        return f"root://dtn-eic.jlab.org//volatile/eic/{path}"
     else:
         raise runtime_exception('Unexpected value for config["remote_provider"]: {config["remote_provider"]}')
 
@@ -74,7 +74,7 @@ rule fetch_epic:
     cache: True
     retries: 3
     shell: """
-xrdcp --debug 2 root://dtn-eic.jlab.org//work/eic2/{output.filepath} {output.filepath}
+xrdcp --debug 2 root://dtn-eic.jlab.org//volatile/eic/{output.filepath} {output.filepath}
 """ if use_xrootd else """
 mc cp S3/eictest/{output.filepath} {output.filepath}
 """ if use_s3 else f"""

--- a/benchmarks/backgrounds/Snakefile
+++ b/benchmarks/backgrounds/Snakefile
@@ -59,10 +59,10 @@ dask worker tcp://$DASK_SCHEDULER --nworkers {threads} --nthreads 1 2>{log.worke
 WORKER_PID=$!
 env \
 MATPLOTLIBRC={input.matplotlibrc} \
-ELECTRON_BEAM_GAS_GEN=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/electron/GETaLM1.0.0-1.0/10GeV/GETaLM1.0.0-1.0_ElectronBeamGas_10GeV_foam_emin10keV_run001.hepmc3.tree.root \
+ELECTRON_BEAM_GAS_GEN=root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/electron/GETaLM1.0.0-1.0/10GeV/GETaLM1.0.0-1.0_ElectronBeamGas_10GeV_foam_emin10keV_run001.hepmc3.tree.root \
 ELECTRON_BEAM_GAS_SIM=$(realpath {input.electron_beam_gas_sim}) \
 PHYSICS_PROCESS_SIM=$(realpath {input.physics_signal_sim}) \
-PROTON_BEAM_GAS_GEN=root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/proton/pythia8.306-1.0/100GeV/pythia8.306-1.0_ProtonBeamGas_100GeV_run001.hepmc3.tree.root \
+PROTON_BEAM_GAS_GEN=root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/proton/pythia8.306-1.0/100GeV/pythia8.306-1.0_ProtonBeamGas_100GeV_run001.hepmc3.tree.root \
 PROTON_BEAM_GAS_SIM=$(realpath {input.proton_beam_gas_sim}) \
 OUTPUT_DIR={output} \
 python {input.script}

--- a/benchmarks/backwards_ecal/Snakefile
+++ b/benchmarks/backwards_ecal/Snakefile
@@ -84,7 +84,7 @@ if config.get("stream_from_xrootd", True) not in [False, "", "0", "false"]:
         params:
             search_path=lambda wildcards: f"EPIC/RECO/{wildcards.CAMPAIGN}/epic_craterlake/SINGLE/{wildcards.PARTICLE}/{wildcards.ENERGY}/{wildcards.PHASE_SPACE}/",
         shell: """
-    xrdfs root://dtn-eic.jlab.org/ ls /work/eic2/{params.search_path} \
+    xrdfs root://dtn-eic.jlab.org/ ls /volatile/eic/{params.search_path} \
       | awk '{{ print "root://dtn-eic.jlab.org/"$1; }}' \
       | sort \
       > {output}
@@ -100,8 +100,8 @@ else:
         params:
             search_path=lambda wildcards: f"EPIC/RECO/{wildcards.CAMPAIGN}/epic_craterlake/SINGLE/{wildcards.PARTICLE}/{wildcards.ENERGY}/{wildcards.PHASE_SPACE}/",
         shell: """
-    xrdfs root://dtn-eic.jlab.org/ ls /work/eic2/{params.search_path} \
-      | sed -e 's#^/work/eic2/##' \
+    xrdfs root://dtn-eic.jlab.org/ ls /volatile/eic/{params.search_path} \
+      | sed -e 's#^/volatile/eic/##' \
       | sort \
       > {output}
     if [ ! -s {output} ]; then

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -36,7 +36,7 @@ ddsim \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
   --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/DIS/NC/{wildcards.EBEAM}x{wildcards.PBEAM}/minQ2={wildcards.MINQ2}/pythia8NCDIS_{wildcards.EBEAM}x{wildcards.PBEAM}_minQ2={wildcards.MINQ2}_beamEffects_xAngle=-0.025_hiDiv_vtxfix_{wildcards.INDEX}.hepmc3.tree.root \
+  --inputFiles root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/NC/{wildcards.EBEAM}x{wildcards.PBEAM}/minQ2={wildcards.MINQ2}/pythia8NCDIS_{wildcards.EBEAM}x{wildcards.PBEAM}_minQ2={wildcards.MINQ2}_beamEffects_xAngle=-0.025_hiDiv_vtxfix_{wildcards.INDEX}.hepmc3.tree.root \
   --outputFile {output}
 """
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Replace /work/eic2 with /volatile/eic in executable code. Docs to follow. To be merged after EVGEN has been migrated (note: backwards_ecal also uses RECO).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: switchover will break)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.