### PR TITLE
fix: sim:timing: fail job when fail ddsim

### DIFF
--- a/benchmarks/timing/run_timing.sh
+++ b/benchmarks/timing/run_timing.sh
@@ -92,11 +92,11 @@ mkdir -p ${timing_dir}
       --compactFile ${compact_path} \
       --outputFile ${output_dir}/${output_file} \
     2>&1 > ${timing_dir}/${ddsim_file}
-echo "For ${nevents} events:"
-cat ${timing_dir}/${timing_file}
 
 if [[ "$?" -ne "0" ]] ; then
   echo "ERROR running npsim"
   exit 1
 fi
 
+echo "For ${nevents} events:"
+cat ${timing_dir}/${timing_file}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This avoids spurious success as in https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/4837441

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No