### PR TITLE
.gitlab-ci.yml: ommit redundant description in github status, report BENCHMARKS_TAG instead

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -55,5 +55,5 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer $GITHUB_TOKEN" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          -d '{"context": "eicweb/detector_benchmarks ('"$DETECTOR_CONFIG"')", "state": "pending", "description": "Waiting for response from the EICweb", "target_url": "${{ fromJson(steps.trigger_eicweb.outputs.json).web_url }}"}' \
+          -d '{"context": "eicweb/detector_benchmarks (nightly, '"$DETECTOR_CONFIG"')", "state": "pending", "description": "Waiting for response from the EICweb", "target_url": "${{ fromJson(steps.trigger_eicweb.outputs.json).web_url }}"}' \
           "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,8 +61,8 @@ stages:
           "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
           -d '{"state":"'"${STATE}"'",
                "target_url":"'"${CI_PIPELINE_URL}"'",
-               "description":"'"${DESCRIPTION} $(TZ=America/New_York date)"'",
-               "context":"eicweb/detector_benchmarks ('"$DETECTOR_CONFIG"')"
+               "description":"'"$(TZ=America/New_York date)"'",
+               "context":"eicweb/detector_benchmarks ('"${BENCHMARKS_TAG}"', '"$DETECTOR_CONFIG"')"
               }' ;
       fi
 
@@ -72,7 +72,6 @@ benchmarks:detector:pending:
   extends: .status
   variables:
     STATE: "pending"
-    DESCRIPTION: "Started..."
   when: always
 
 common:setup:
@@ -197,7 +196,6 @@ benchmarks:detector:success:
   extends: .status
   variables:
     STATE: "success"
-    DESCRIPTION: "Succeeded!"
   after_script:
     # Cleanup scratch space
     - rm -rfv $LOCAL_DATA_PATH
@@ -209,7 +207,6 @@ benchmarks:detector:failure:
   extends: .status
   variables:
     STATE: "failure"
-    DESCRIPTION: "Failed!"
   when: on_failure
 
 pages:


### PR DESCRIPTION
Since GITHUB_PR and others are passed from eic_container to detector_benchmarks and others, we observe 3 additional statuses:
<img width="515" alt="image" src="https://github.com/user-attachments/assets/18d3c989-0f3b-46a7-8c89-ef5cf1a86451" />
But in reality there should be 6 for stable and nightly. This introduces pipeline tag into the job name. Description is truncated to remove some redundant messages that are already conveyed via status icon and GitHub UI.