### PR TITLE
tracking_performances{,_dis}: add simulation caching

### DIFF
--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -13,7 +13,7 @@ rule tracking_performance_sim:
         PHASE_SPACE="(3to50|45to135|130to177)deg",
         INDEX=r"\d{4}",
     params:
-        N_EVENTS=10000
+        N_EVENTS=10000,
         SEED=lambda wildcards: "1" + wildcards.INDEX,
         DETECTOR_PATH=os.environ["DETECTOR_PATH"],
         DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -2,6 +2,7 @@ rule tracking_performance_sim:
     input:
         steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        geometry_lib=find_epic_libraries(),
     output:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
     log:
@@ -13,6 +14,16 @@ rule tracking_performance_sim:
         INDEX=r"\d{4}",
     params:
         N_EVENTS=10000
+        SEED=lambda wildcards: "1" + wildcards.INDEX,
+        DETECTOR_PATH=os.environ["DETECTOR_PATH"],
+        DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,
+        PARTICLE=lambda wildcards: wildcards.PARTICLE,
+        ENERGY=lambda wildcards: wildcards.ENERGY,
+        PHASE_SPACE=lambda wildcards: wildcards.PHASE_SPACE,
+        INDEX=lambda wildcards: wildcards.INDEX,
+        DD4HEP_HASH=get_spack_package_hash("dd4hep"),
+        NPSIM_HASH=get_spack_package_hash("npsim"),
+    cache: True
     shell:
         """
 set -m # monitor mode to prevent lingering processes
@@ -20,11 +31,11 @@ exec ddsim \
   --runType batch \
   --enableGun \
   --steeringFile "{input.steering_file}" \
-  --random.seed 1{wildcards.INDEX} \
+  --random.seed {params.SEED} \
   --filter.tracker edep0 \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
-  --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
+  --compactFile {params.DETECTOR_PATH}/{params.DETECTOR_CONFIG}.xml \
   --outputFile {output}
 """
 
@@ -38,9 +49,17 @@ rule tracking_performance_recon:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.tree.edm4eic.root.log",
     wildcard_constraints:
         INDEX=r"\d{4}",
+    params:
+        DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,
+        PARTICLE=lambda wildcards: wildcards.PARTICLE,
+        ENERGY=lambda wildcards: wildcards.ENERGY,
+        PHASE_SPACE=lambda wildcards: wildcards.PHASE_SPACE,
+        INDEX=lambda wildcards: wildcards.INDEX,
+        EICRECON_HASH=get_spack_package_hash("eicrecon"),
+    cache: True
     shell: """
 set -m # monitor mode to prevent lingering processes
-exec env DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} \
+exec env DETECTOR_CONFIG={params.DETECTOR_CONFIG} \
   eicrecon {input} -Ppodio:output_file={output} \
   -Ppodio:output_collections=MCParticles,CentralCKFTrajectories,CentralCKFTrackParameters,CentralCKFSeededTrackParameters,CentralCKFTruthSeededTrackParameters,CentralTrackVertices
 """

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -23,20 +23,31 @@ rule trk_dis_compile:
 rule trk_dis_sim:
     input:
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        geometry_lib=find_epic_libraries(),
     output:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4hep.root",
     params:
         N_EVENTS=200,
+        EBEAM=lambda wildcards: wildcards.EBEAM,
+        PBEAM=lambda wildcards: wildcards.PBEAM,
+        MINQ2=lambda wildcards: wildcards.MINQ2,
+        SEED=lambda wildcards: "1" + wildcards.INDEX,
+        DETECTOR_PATH=os.environ["DETECTOR_PATH"],
+        DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,
+        DD4HEP_HASH=get_spack_package_hash("dd4hep"),
+        NPSIM_HASH=get_spack_package_hash("npsim"),
+    cache: True
     shell:
         """
 ddsim \
   --runType batch \
   --part.minimalKineticEnergy 1000*GeV  \
+  --random.seed {params.SEED} \
   --filter.tracker edep0 \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
-  --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/NC/{wildcards.EBEAM}x{wildcards.PBEAM}/minQ2={wildcards.MINQ2}/pythia8NCDIS_{wildcards.EBEAM}x{wildcards.PBEAM}_minQ2={wildcards.MINQ2}_beamEffects_xAngle=-0.025_hiDiv_vtxfix_{wildcards.INDEX}.hepmc3.tree.root \
+  --compactFile {params.DETECTOR_PATH}/{params.DETECTOR_CONFIG}.xml \
+  --inputFiles root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/NC/{params.EBEAM}x{params.PBEAM}/minQ2={params.MINQ2}/pythia8NCDIS_{params.EBEAM}x{params.PBEAM}_minQ2={params.MINQ2}_beamEffects_xAngle=-0.025_hiDiv_vtxfix_{params.INDEX}.hepmc3.tree.root \
   --outputFile {output}
 """
 
@@ -46,6 +57,14 @@ rule trk_dis_reco:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4hep.root",
     output:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4eic.root",
+    params:
+        DETECTOR_CONFIG=lambda wildcards: wildcards.DETECTOR_CONFIG,
+        EBEAM=lambda wildcards: wildcards.EBEAM,
+        PBEAM=lambda wildcards: wildcards.PBEAM,
+        MINQ2=lambda wildcards: wildcards.MINQ2,
+        INDEX=lambda wildcards: wildcards.INDEX,
+        EICRECON_HASH=get_spack_package_hash("eicrecon"),
+    cache: True
     shell:
         """
 set -m # monitor mode to prevent lingering processes

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -29,6 +29,7 @@ rule trk_dis_sim:
     params:
         N_EVENTS=200,
         EBEAM=lambda wildcards: wildcards.EBEAM,
+        INDEX=lambda wildcards: wildcards.INDEX,
         PBEAM=lambda wildcards: wildcards.PBEAM,
         MINQ2=lambda wildcards: wildcards.MINQ2,
         SEED=lambda wildcards: "1" + wildcards.INDEX,


### PR DESCRIPTION
This is the last benchmark that is missing caching. Should be similar to all previous cases.