### PR TITLE
tracking_performance: preserve result/ for tracking_performance_local

### DIFF
--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -27,7 +27,9 @@ collect_results:tracking_performance:
     - "bench:tracking_performance"
   script:
     - ls -lrht
+    - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output tracking_performance_local
+    - mv results{_save,}/
 
 bench:tracking_performance_campaigns:
   extends: .det_benchmark


### PR DESCRIPTION
Noticed the artifacts are empty, only 24.10.1 is available. This will fix that.