### PR TITLE
feat: centralize gitlab job definitions more

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,8 @@ get_data:
     - cd ${LOCAL_DATA_PATH} && git clone --depth=1 https://eicweb.phy.anl.gov/EIC/datasets.git datasets
 
 .det_benchmark:
+  variables:
+    BENCHMARK_DIR: "results/${DETECTOR_CONFIG}/"
   needs:
     - ["get_data","common:setup"]
   before_script:
@@ -122,6 +124,27 @@ get_data:
     max: 2
     when:
       - runner_system_failure
+
+.det_benchmark:sim:
+  extends: .det_benchmark
+  stage: simulation
+  timeout: 1 hours
+
+.det_benchmark:bench:
+  extends: .det_benchmark
+  stage: benchmarks
+  script:
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 ${BENCHMARK_DIR}/$(echo ${CI_JOB_NAME} | rev | cut -d: -f1 | rev)
+
+.det_benchmark:collect:
+  extends: .det_benchmark
+  stage: collect
+  when: always
+  script:
+    - ls -lrht
+    - mv results{,_save}/ # move results directory out of the way to preserve it
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output ${BENCHMARK_DIR}/$(echo ${CI_JOB_NAME} | rev | cut -d: -f1 | rev)
+    - mv results{_save,}/
 
 include: 
   - local: 'benchmarks/backgrounds/config.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,14 +133,14 @@ get_data:
 .det_benchmark:bench:
   extends: .det_benchmark
   stage: benchmarks
-  script:
+  after_script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 ${BENCHMARK_DIR}/$(echo ${CI_JOB_NAME} | rev | cut -d: -f1 | rev)
 
 .det_benchmark:collect:
   extends: .det_benchmark
   stage: collect
   when: always
-  script:
+  after_script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it
     - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output ${BENCHMARK_DIR}/$(echo ${CI_JOB_NAME} | rev | cut -d: -f1 | rev)

--- a/benchmarks/femc_electron/config.yml
+++ b/benchmarks/femc_electron/config.yml
@@ -1,6 +1,5 @@
 sim:femc_electron:
-  extends: .det_benchmark
-  stage: simulate
+  extends: .det_benchmark:sim
   parallel:
     matrix:
       - P: 10
@@ -11,27 +10,13 @@ sim:femc_electron:
       - P: 60
       - P: 70
       - P: 80
-  timeout: 1 hours
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/femc_electron/epic_craterlake_rec_e-_${P}GeV.edm4eic.root
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
 
 bench:femc_electron:
-  extends: .det_benchmark
-  stage: benchmarks
+  extends: .det_benchmark:bench
   needs: ["sim:femc_electron"]
-  script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_craterlake/femc_electron
 
 collect_results:femc_electron:
-  extends: .det_benchmark
-  stage: collect
+  extends: .det_benchmark:collect
   needs: ["bench:femc_electron"]
-  script:
-    - ls -al
-    - mv results{,_save}/ # move results directory out of the way to preserve it
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output results/epic_craterlake/femc_electron
-    - mv results{_save,}/

--- a/benchmarks/femc_photon/config.yml
+++ b/benchmarks/femc_photon/config.yml
@@ -1,6 +1,5 @@
 sim:femc_photon:
-  extends: .det_benchmark
-  stage: simulate
+  extends: .det_benchmark:sim
   parallel:
     matrix:
       - P: 10
@@ -11,27 +10,13 @@ sim:femc_photon:
       - P: 60
       - P: 70
       - P: 80
-  timeout: 1 hours
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/femc_photon/epic_craterlake_rec_photon_${P}GeV.edm4eic.root
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
 
 bench:femc_photon:
-  extends: .det_benchmark
-  stage: benchmarks
+  extends: .det_benchmark:bench
   needs: ["sim:femc_photon"]
-  script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_craterlake/femc_photon
 
 collect_results:femc_photon:
-  extends: .det_benchmark
-  stage: collect
+  extends: .det_benchmark:collect
   needs: ["bench:femc_photon"]
-  script:
-    - ls -al
-    - mv results{,_save}/ # move results directory out of the way to preserve it
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output results/epic_craterlake/femc_photon
-    - mv results{_save,}/

--- a/benchmarks/femc_pi0/config.yml
+++ b/benchmarks/femc_pi0/config.yml
@@ -1,6 +1,5 @@
 sim:femc_pi0:
-  extends: .det_benchmark
-  stage: simulate
+  extends: .det_benchmark:sim
   parallel:
     matrix:
       - P: 10
@@ -11,26 +10,14 @@ sim:femc_pi0:
       - P: 60
       - P: 70
       - P: 80
+  timeout: 2 hours
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/femc_pi0/epic_craterlake_rec_pi0_${P}GeV.edm4eic.root
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
 
 bench:femc_pi0:
-  extends: .det_benchmark
-  stage: benchmarks
+  extends: .det_benchmark:bench
   needs: ["sim:femc_pi0"]
-  script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_craterlake/femc_pi0
 
 collect_results:femc_pi0:
-  extends: .det_benchmark
-  stage: collect
+  extends: .det_benchmark:collect
   needs: ["bench:femc_pi0"]
-  script:
-    - ls -al
-    - mv results{,_save}/ # move results directory out of the way to preserve it
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output results/epic_craterlake/femc_pi0
-    - mv results{_save,}/


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that `collect` is always run, to make sure `snakemake --delete-all-output` is run. It centralizes this functionality for inheritance.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.