### PR TITLE
feat: always run collect jobs

### DIFF
--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -43,6 +43,7 @@ collect_results:backwards_ecal:
   stage: collect
   needs:
     - "bench:backwards_ecal"
+  when: always
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/calo_pid/config.yml
+++ b/benchmarks/calo_pid/config.yml
@@ -38,6 +38,7 @@ collect_results:calo_pid:
   stage: collect
   needs:
     - "bench:calo_pid"
+  when: always
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -22,6 +22,7 @@ collect_results:ecal_gaps:
   stage: collect
   needs:
     - "bench:ecal_gaps"
+  when: always
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/femc_electron/config.yml
+++ b/benchmarks/femc_electron/config.yml
@@ -30,6 +30,7 @@ collect_results:femc_electron:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:femc_electron"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/femc_photon/config.yml
+++ b/benchmarks/femc_photon/config.yml
@@ -30,6 +30,7 @@ collect_results:femc_photon:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:femc_photon"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/femc_pi0/config.yml
+++ b/benchmarks/femc_pi0/config.yml
@@ -29,6 +29,7 @@ collect_results:femc_pi0:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:femc_pi0"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/insert_muon/config.yml
+++ b/benchmarks/insert_muon/config.yml
@@ -22,6 +22,7 @@ collect_results:insert_muon:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:insert_muon"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/insert_neutron/config.yml
+++ b/benchmarks/insert_neutron/config.yml
@@ -28,6 +28,7 @@ collect_results:insert_neutron:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:insert_neutron"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/insert_tau/config.yml
+++ b/benchmarks/insert_tau/config.yml
@@ -29,6 +29,7 @@ collect_results:insert_tau:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:insert_tau"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/lfhcal/config.yml
+++ b/benchmarks/lfhcal/config.yml
@@ -23,6 +23,7 @@ collect_results:lfhcal:
   stage: collect
   needs:
     - "bench:lfhcal"
+  when: always
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it
@@ -41,6 +42,7 @@ collect_results:lfhcal_campaigns:
   stage: collect
   needs:
     - "bench:lfhcal_campaigns"
+  when: always
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/zdc_lambda/config.yml
+++ b/benchmarks/zdc_lambda/config.yml
@@ -29,6 +29,7 @@ collect_results:zdc_lambda:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:zdc_lambda"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/zdc_lyso/config.yml
+++ b/benchmarks/zdc_lyso/config.yml
@@ -13,6 +13,7 @@ collect_results:zdc_lyso:
   stage: collect
   needs:
     - "sim:zdc_lyso"
+  when: always
   script:
     - ls -lrht
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/zdc_pi0/config.yml
+++ b/benchmarks/zdc_pi0/config.yml
@@ -26,6 +26,7 @@ collect_results:zdc_pi0:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:zdc_pi0"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it

--- a/benchmarks/zdc_sigma/config.yml
+++ b/benchmarks/zdc_sigma/config.yml
@@ -29,6 +29,7 @@ collect_results:zdc_sigma:
   extends: .det_benchmark
   stage: collect
   needs: ["bench:zdc_sigma"]
+  when: always
   script:
     - ls -al
     - mv results{,_save}/ # move results directory out of the way to preserve it


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds `when: always` to all `collect` jobs that only run the standard content with `snakemake --delete-output-files`.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue: some output files not deleted)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.