### PR TITLE
fix(ci):  don't run status jobs when GITHUB_SHA undefined

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,20 +51,20 @@ stages:
 
 .status:
   image: curlimages/curl:latest
+  rules:
+    - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
   script:
     - |
-      if [ -n "${GITHUB_SHA}" ] ; then
-        curl \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${GITHUB_REPO_STATUS_TOKEN}" \
-          "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-          -d '{"state":"'"${STATE}"'",
-               "target_url":"'"${CI_PIPELINE_URL}"'",
-               "description":"'"$(TZ=America/New_York date)"'",
-               "context":"eicweb/detector_benchmarks ('"${BENCHMARKS_TAG}"', '"$DETECTOR_CONFIG"')"
-              }' ;
-      fi
+      curl \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: token ${GITHUB_REPO_STATUS_TOKEN}" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+        -d '{"state":"'"${STATE}"'",
+             "target_url":"'"${CI_PIPELINE_URL}"'",
+             "description":"'"$(TZ=America/New_York date)"'",
+             "context":"eicweb/detector_benchmarks ('"${BENCHMARKS_TAG}"', '"$DETECTOR_CONFIG"')"
+            }' ;
 
 
 benchmarks:detector:pending:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that the status jobs won't be attempted when they are going to fail anyway.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: job is run that doesn't do anything)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.