### PR TITLE
fix(ci): use interruptible resource_group

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,8 @@ workflow:
 default:
   tags:
     - phy-scratch
+  resource_group: $BENCHMARKS_CONTAINER:$BENCHMARKS_TAG:$GITHUB_REPOSITORY:$GITHUB_SHA
+  interruptible: true
   artifacts:
     expire_in: 72 hours 
     paths:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR aims to make jobs interruptible within a resource group. This may allow interrupting older pipelines when a newer trigger is received on the same branch.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: each commit generates a pipeline that tries to run to completion)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.