### PR TITLE
.gitlab-ci.yml: reset file timestamps to avoid rerunning simulations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ get_data:
     - |
       for file in $(git ls-files); do
         time="$(git log --pretty=format:%cd -n 1 --date=format:%Y%m%d%H%M.%S --date-order -- "$file")"
-        touch -t "$time" "$file"
+        touch -m -t "$time" "$file"
       done
     - stat -c %x,%z,%n *
     - ls -lrtha

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,7 @@ get_data:
     - ln -s "${LOCAL_DATA_PATH}/sim_output" "${DETECTOR_CONFIG}/sim_output"
     - ln -s "../results" "${DETECTOR_CONFIG}/results"
     - mkdir -p "$SNAKEMAKE_OUTPUT_CACHE"
+    - stat -c %x,%z,%n *
     # GitLab CI will have new timestamps in each job, which messes with
     # Snakemake outdated file detection.  This resets file timestamps according
     # to latest modification in git.
@@ -125,6 +126,7 @@ get_data:
         time="$(git log --pretty=format:%cd -n 1 --date=format:%Y%m%d%H%M.%S --date-order -- "$file")"
         touch -t "$time" "$file"
       done
+    - stat -c %x,%z,%n *
     - ls -lrtha
   retry:
     max: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,7 @@ get_data:
     - |
       for file in $(git ls-files); do
         time="$(git log --pretty=format:%cd -n 1 --date=format:%Y%m%d%H%M.%S --date-order -- "$file")"
-        touch -m -t "$time" "$file"
+        touch -t "$time" "$file"
       done
     - ls -lrtha
   retry:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,14 @@ get_data:
     - ln -s "${LOCAL_DATA_PATH}/sim_output" "${DETECTOR_CONFIG}/sim_output"
     - ln -s "../results" "${DETECTOR_CONFIG}/results"
     - mkdir -p "$SNAKEMAKE_OUTPUT_CACHE"
+    # GitLab CI will have new timestamps in each job, which messes with
+    # Snakemake outdated file detection.  This resets file timestamps according
+    # to latest modification in git.
+    - |
+      for file in $(git ls-files); do
+        time="$(git log --pretty=format:%cd -n 1 --date=format:%Y%m%d%H%M.%S --date-order -- "$file")"
+        touch -m -t "$time" "$file"
+      done
     - ls -lrtha
   retry:
     max: 2


### PR DESCRIPTION
We run a sequence of GitLab CI jobs each executing snakemake with ever higher level targets. The products of those targets (e.g. simulations) exist on a shared disk, but checkout of detector_benchmarks repo is private to each job and receives an updated timestamp every time GitLab produces a copy. This messes with targets that depend on files coming from the detector_benchmarks repo itself. This is an attempt at fixing that behaviour.

cc @simonge