### PR TITLE
lfhcal,zdc_neutron: MCParticles.momentum is now double, not float

### DIFF
--- a/benchmarks/lfhcal/LFHCAL_Performance.C
+++ b/benchmarks/lfhcal/LFHCAL_Performance.C
@@ -50,12 +50,12 @@ void LFHCAL_Performance(TString filename="tracking_output",TString particle="pi-
   
    // MC and Reco information 
    TTreeReaderArray<Float_t> charge(myReader, "MCParticles.charge"); 
-   TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x"); 
-   TTreeReaderArray<Double_t> vy_mc(myReader, "MCParticles.vertex.y"); 
+   TTreeReaderArray<Double_t> vx_mc(myReader, "MCParticles.vertex.x");
+   TTreeReaderArray<Double_t> vy_mc(myReader, "MCParticles.vertex.y");
    TTreeReaderArray<Double_t> vz_mc(myReader, "MCParticles.vertex.z");
-   TTreeReaderArray<Float_t> px_mc(myReader, "MCParticles.momentum.x"); 
-   TTreeReaderArray<Float_t> py_mc(myReader, "MCParticles.momentum.y"); 
-   TTreeReaderArray<Float_t> pz_mc(myReader, "MCParticles.momentum.z");
+   TTreeReaderArray<Double_t> px_mc(myReader, "MCParticles.momentum.x");
+   TTreeReaderArray<Double_t> py_mc(myReader, "MCParticles.momentum.y");
+   TTreeReaderArray<Double_t> pz_mc(myReader, "MCParticles.momentum.z");
    TTreeReaderArray<Int_t> status(myReader, "MCParticles.generatorStatus"); 
    TTreeReaderArray<Int_t> pdg(myReader, "MCParticles.PDG");
 

--- a/benchmarks/zdc_neutron/analysis/fwd_neutrons_geant.C
+++ b/benchmarks/zdc_neutron/analysis/fwd_neutrons_geant.C
@@ -116,9 +116,9 @@ void fwd_neutrons_geant(std::string inputfile, std::string outputfile){
 
     TTreeReaderArray<int>   gen_status(tr, "MCParticles.generatorStatus");
     TTreeReaderArray<int>   gen_pid(tr, "MCParticles.PDG");
-    TTreeReaderArray<float> gen_px(tr, "MCParticles.momentum.x");
-    TTreeReaderArray<float> gen_py(tr, "MCParticles.momentum.y");
-    TTreeReaderArray<float> gen_pz(tr, "MCParticles.momentum.z");
+    TTreeReaderArray<double> gen_px(tr, "MCParticles.momentum.x");
+    TTreeReaderArray<double> gen_py(tr, "MCParticles.momentum.y");
+    TTreeReaderArray<double> gen_pz(tr, "MCParticles.momentum.z");
     TTreeReaderArray<double> gen_mass(tr, "MCParticles.mass");
     TTreeReaderArray<float> gen_charge(tr, "MCParticles.charge");
     TTreeReaderArray<double> gen_vx(tr, "MCParticles.vertex.x");

--- a/benchmarks/zdc_neutron/analysis/fwd_neutrons_recon.C
+++ b/benchmarks/zdc_neutron/analysis/fwd_neutrons_recon.C
@@ -92,9 +92,9 @@ void fwd_neutrons_recon(std::string inputfile, std::string outputfile){
 
     TTreeReaderArray<int>   gen_status(tr, "MCParticles.generatorStatus");
     TTreeReaderArray<int>   gen_pid(tr, "MCParticles.PDG");
-    TTreeReaderArray<float> gen_px(tr, "MCParticles.momentum.x");
-    TTreeReaderArray<float> gen_py(tr, "MCParticles.momentum.y");
-    TTreeReaderArray<float> gen_pz(tr, "MCParticles.momentum.z");
+    TTreeReaderArray<double> gen_px(tr, "MCParticles.momentum.x");
+    TTreeReaderArray<double> gen_py(tr, "MCParticles.momentum.y");
+    TTreeReaderArray<double> gen_pz(tr, "MCParticles.momentum.z");
     TTreeReaderArray<double> gen_mass(tr, "MCParticles.mass");
     TTreeReaderArray<float> gen_charge(tr, "MCParticles.charge");
     TTreeReaderArray<double> gen_vx(tr, "MCParticles.vertex.x");


### PR DESCRIPTION
This is an issue with running benchmarks with after EDM4hep update (happened long time ago, actually).
```
Error in <TTreeReaderArrayBase::CreateContentProxy()>: The branch MCParticles.momentum.x contains data of type double. It cannot be accessed by a TTreeReaderArray<float>
Error in <TTreeReaderArrayBase::CreateContentProxy()>: The branch MCParticles.momentum.y contains data of type double. It cannot be accessed by a TTreeReaderArray<float>
Error in <TTreeReaderArrayBase::CreateContentProxy()>: The branch MCParticles.momentum.z contains data of type double. It cannot be accessed by a TTreeReaderArray<float>
```
lfhcal: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/5766771/raw
zdc_neutron: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/5766779

Previous similar fixes: https://github.com/eic/detector_benchmarks/pull/170 and https://github.com/eic/detector_benchmarks/pull/113/files#diff-f814f8908219fcd32581911ef76623dfbb0d8aa528d58dcad51352a45fe87a86R82