### PR TITLE
treewide: add warmup dependency to reco steps

### DIFF
--- a/benchmarks/backwards_ecal/Snakefile
+++ b/benchmarks/backwards_ecal/Snakefile
@@ -46,6 +46,7 @@ exec ddsim \
 rule backwards_ecal_recon:
     input:
         "sim_output/backwards_ecal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/backwards_ecal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/calo_pid/Snakefile
+++ b/benchmarks/calo_pid/Snakefile
@@ -52,6 +52,7 @@ exec ddsim \
 rule calo_pid_recon:
     input:
         "sim_output/calo_pid/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/calo_pid/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -42,6 +42,7 @@ exec ddsim \
 rule ecal_gaps_recon:
     input:
         "sim_output/ecal_gaps/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/ecal_gaps/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/femc_electron/Snakefile
+++ b/benchmarks/femc_electron/Snakefile
@@ -50,6 +50,7 @@ npsim \
 rule femc_electron_recon:
     input:
         SIM_FILE="sim_output/femc_electron/{DETECTOR_CONFIG}_sim_e-_{P}GeV.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         REC_FILE="sim_output/femc_electron/{DETECTOR_CONFIG}_rec_e-_{P}GeV.edm4eic.root",
     params:

--- a/benchmarks/femc_photon/Snakefile
+++ b/benchmarks/femc_photon/Snakefile
@@ -50,6 +50,7 @@ npsim \
 rule femc_photon_recon:
     input:
         SIM_FILE="sim_output/femc_photon/{DETECTOR_CONFIG}_sim_photon_{P}GeV.edm4hep.root"
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         REC_FILE="sim_output/femc_photon/{DETECTOR_CONFIG}_rec_photon_{P}GeV.edm4eic.root"
     params:

--- a/benchmarks/femc_pi0/Snakefile
+++ b/benchmarks/femc_pi0/Snakefile
@@ -50,6 +50,7 @@ npsim \
 rule femc_pi0_recon:
     input:
         SIM_FILE="sim_output/femc_pi0/{DETECTOR_CONFIG}_sim_pi0_{P}GeV.edm4hep.root"
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         REC_FILE="sim_output/femc_pi0/{DETECTOR_CONFIG}_rec_pi0_{P}GeV.edm4eic.root"
     params:

--- a/benchmarks/insert_muon/Snakefile
+++ b/benchmarks/insert_muon/Snakefile
@@ -44,6 +44,7 @@ npsim \
 rule insert_muon_recon:
     input:
         SIM_FILE="sim_output/insert_muon/{DETECTOR_CONFIG}_sim_mu-_{P}GeV_{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         REC_FILE="sim_output/insert_muon/{DETECTOR_CONFIG}_rec_mu-_{P}GeV_{INDEX}.edm4hep.root",
     params:

--- a/benchmarks/insert_neutron/Snakefile
+++ b/benchmarks/insert_neutron/Snakefile
@@ -45,6 +45,7 @@ npsim \
 rule insert_neutron_recon:
     input:
         SIM_FILE="sim_output/insert_neutron/{DETECTOR_CONFIG}_sim_neutron_{P}GeV_{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         REC_FILE="sim_output/insert_neutron/{DETECTOR_CONFIG}_rec_neutron_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/insert_tau/Snakefile
+++ b/benchmarks/insert_tau/Snakefile
@@ -50,6 +50,7 @@ npsim \
 rule insert_tau_recon:
     input:
         SIM_FILE="sim_output/insert_tau/{DETECTOR_CONFIG}_sim_tau-_{P}GeV_{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         REC_FILE="sim_output/insert_tau/{DETECTOR_CONFIG}_rec_tau-_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/lfhcal/Snakefile
+++ b/benchmarks/lfhcal/Snakefile
@@ -38,6 +38,7 @@ ddsim \
 rule lfhcal_recon:
     input:
         "sim_output/lfhcal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/lfhcal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -43,6 +43,7 @@ exec ddsim \
 rule tracking_performance_recon:
     input:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -56,6 +56,7 @@ ddsim \
 rule trk_dis_reco:
     input:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/zdc_lambda/Snakefile
+++ b/benchmarks/zdc_lambda/Snakefile
@@ -42,6 +42,7 @@ npsim \
 rule zdc_lambda_recon:
         input:
                 SIM_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV_{INDEX}.edm4hep.root",
+                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
         output:
                 REC_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_rec_lambda_dec_{P}GeV_{INDEX}.edm4eic.root",
         params:

--- a/benchmarks/zdc_lyso/Snakefile
+++ b/benchmarks/zdc_lyso/Snakefile
@@ -51,6 +51,7 @@ npsim \
 rule zdc_lyso_reco:
     input:
         "sim_output/zdc_lyso/{DETECTOR_CONFIG}_{PARTICLE}_{BEAM_ENERGY}GeV_theta_{THETA_MIN}deg_thru_{THETA_MAX}deg.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/zdc_lyso/{DETECTOR_CONFIG}_{PARTICLE}_{BEAM_ENERGY}GeV_theta_{THETA_MIN}deg_thru_{THETA_MAX}deg.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/zdc_neutron/Snakefile
+++ b/benchmarks/zdc_neutron/Snakefile
@@ -37,6 +37,7 @@ exec npsim \
 rule zdc_neutron_reco:
     input:
         "sim_output/zdc_neutron/{DETECTOR_CONFIG}/fwd_neutrons.edm4hep.root",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim_output/zdc_neutron/{DETECTOR_CONFIG}/fwd_neutrons.edm4eic.root",
     shell:

--- a/benchmarks/zdc_photon/Snakefile
+++ b/benchmarks/zdc_photon/Snakefile
@@ -45,6 +45,7 @@ npsim \
 rule zdc_photon_recon:
         input:
                 SIM_FILE="sim_output/zdc_photon/{DETECTOR_CONFIG}_sim_zdc_photon_{P}GeV_{INDEX}.edm4hep.root"
+                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
         output:
                 REC_FILE="sim_output/zdc_photon/{DETECTOR_CONFIG}_rec_zdc_photon_{P}GeV_{INDEX}.edm4eic.root"
         params:

--- a/benchmarks/zdc_pi0/Snakefile
+++ b/benchmarks/zdc_pi0/Snakefile
@@ -43,6 +43,7 @@ npsim \
 rule zdc_pi0_recon:
         input:
                 SIM_FILE="sim_output/zdc_pi0/{DETECTOR_CONFIG}_sim_zdc_pi0_{P}GeV_{INDEX}.edm4hep.root",
+                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
         output:
                 REC_FILE="sim_output/zdc_pi0/{DETECTOR_CONFIG}_rec_zdc_pi0_{P}GeV_{INDEX}.edm4eic.root",
         params:

--- a/benchmarks/zdc_sigma/Snakefile
+++ b/benchmarks/zdc_sigma/Snakefile
@@ -42,6 +42,7 @@ npsim \
 rule zdc_sigma_recon:
         input:
                 SIM_FILE="sim_output/zdc_sigma/{DETECTOR_CONFIG}_sim_sigma_dec_{P}GeV_{INDEX}.edm4hep.root",
+                warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
         output:
                 REC_FILE="sim_output/zdc_sigma/{DETECTOR_CONFIG}_rec_sigma_dec_{P}GeV_{INDEX}.edm4eic.root",
         params:


### PR DESCRIPTION
Warmup is needed for reconstruction as well, in case simulation was cached and calibration files are not available.