### PR TITLE
treewide: mark warmup as ancient

### DIFF
--- a/benchmarks/backgrounds/Snakefile
+++ b/benchmarks/backgrounds/Snakefile
@@ -4,7 +4,7 @@ import shutil
 
 rule backgrounds_sim:
     input:
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/{DETECTOR_CONFIG}/backgrounds/{PATH}.edm4hep.root",
     log:

--- a/benchmarks/backwards_ecal/Snakefile
+++ b/benchmarks/backwards_ecal/Snakefile
@@ -8,7 +8,7 @@ def get_n_events(wildcards):
 rule backwards_ecal_sim:
     input:
         steering_file=ancient("EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer"),
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         "sim_output/backwards_ecal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
@@ -46,7 +46,7 @@ exec ddsim \
 rule backwards_ecal_recon:
     input:
         "sim_output/backwards_ecal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/backwards_ecal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/calo_pid/Snakefile
+++ b/benchmarks/calo_pid/Snakefile
@@ -3,7 +3,7 @@ def format_energy_for_dd4hep(s):
 
 rule calo_pid_sim:
     input:
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         "sim_output/calo_pid/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY_MIN}to{ENERGY_MAX}/{THETA_MIN}to{THETA_MAX}deg/{PARTICLE}_{ENERGY}_{THETA_MIN}to{THETA_MAX}deg.{INDEX}.edm4hep.root",
@@ -52,7 +52,7 @@ exec ddsim \
 rule calo_pid_recon:
     input:
         "sim_output/calo_pid/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/calo_pid/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/ecal_gaps/Snakefile
+++ b/benchmarks/ecal_gaps/Snakefile
@@ -4,7 +4,7 @@ import os
 rule ecal_gaps_sim:
     input:
         steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         "sim_output/ecal_gaps/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
@@ -42,7 +42,7 @@ exec ddsim \
 rule ecal_gaps_recon:
     input:
         "sim_output/ecal_gaps/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/ecal_gaps/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/femc_electron/Snakefile
+++ b/benchmarks/femc_electron/Snakefile
@@ -24,7 +24,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},"{output.GEN_FILE}", "e-", {para
 rule femc_electron_simulate:
     input:
         GEN_FILE="sim_output/femc_electron/e-_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/femc_electron/{DETECTOR_CONFIG}_sim_e-_{P}GeV.edm4hep.root",
@@ -50,7 +50,7 @@ exec npsim \
 rule femc_electron_recon:
     input:
         SIM_FILE="sim_output/femc_electron/{DETECTOR_CONFIG}_sim_e-_{P}GeV.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/femc_electron/{DETECTOR_CONFIG}_rec_e-_{P}GeV.edm4eic.root",
     params:

--- a/benchmarks/femc_photon/Snakefile
+++ b/benchmarks/femc_photon/Snakefile
@@ -24,7 +24,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},"{output.GEN_FILE}", "gamma", {p
 rule femc_photon_simulate:
     input:
         GEN_FILE="sim_output/femc_photon/photon_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/femc_photon/{DETECTOR_CONFIG}_sim_photon_{P}GeV.edm4hep.root",
@@ -50,7 +50,7 @@ exec npsim \
 rule femc_photon_recon:
     input:
         SIM_FILE="sim_output/femc_photon/{DETECTOR_CONFIG}_sim_photon_{P}GeV.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/femc_photon/{DETECTOR_CONFIG}_rec_photon_{P}GeV.edm4eic.root",
     params:

--- a/benchmarks/femc_pi0/Snakefile
+++ b/benchmarks/femc_pi0/Snakefile
@@ -24,7 +24,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},"{output.GEN_FILE}", "pi0", {par
 rule femc_pi0_simulate:
     input:
         GEN_FILE="sim_output/femc_pi0/pi0_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     params:
         N_EVENTS=get_n_events,
@@ -50,7 +50,7 @@ exec npsim \
 rule femc_pi0_recon:
     input:
         SIM_FILE="sim_output/femc_pi0/{DETECTOR_CONFIG}_sim_pi0_{P}GeV.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/femc_pi0/{DETECTOR_CONFIG}_rec_pi0_{P}GeV.edm4eic.root",
     params:

--- a/benchmarks/insert_muon/Snakefile
+++ b/benchmarks/insert_muon/Snakefile
@@ -16,7 +16,7 @@ root -l -b -q '{input.script}({params.NEVENTS_GEN},"{output.GEN_FILE}", "mu-", {
 rule insert_muon_simulate:
     input:
         GEN_FILE="sim_output/insert_muon/mu-_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/insert_muon/{DETECTOR_CONFIG}_sim_mu-_{P}GeV_{INDEX}.edm4hep.root",
@@ -45,7 +45,7 @@ exec npsim \
 rule insert_muon_recon:
     input:
         SIM_FILE="sim_output/insert_muon/{DETECTOR_CONFIG}_sim_mu-_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/insert_muon/{DETECTOR_CONFIG}_rec_mu-_{P}GeV_{INDEX}.edm4hep.root",
     params:

--- a/benchmarks/insert_neutron/Snakefile
+++ b/benchmarks/insert_neutron/Snakefile
@@ -17,7 +17,7 @@ root -l -b -q '{input.script}({params.NEVENTS_GEN},"{output.GEN_FILE}", "neutron
 rule insert_neutron_simulate:
     input:
         GEN_FILE="sim_output/insert_neutron/neutron_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/insert_neutron/{DETECTOR_CONFIG}_sim_neutron_{P}GeV_{INDEX}.edm4hep.root",
@@ -46,7 +46,7 @@ exec npsim \
 rule insert_neutron_recon:
     input:
         SIM_FILE="sim_output/insert_neutron/{DETECTOR_CONFIG}_sim_neutron_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/insert_neutron/{DETECTOR_CONFIG}_rec_neutron_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/insert_tau/Snakefile
+++ b/benchmarks/insert_tau/Snakefile
@@ -22,7 +22,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},"{output.GEN_FILE}", "tau-", {pa
 rule insert_tau_simulate:
     input:
         GEN_FILE="sim_output/insert_tau/tau-_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/insert_tau/{DETECTOR_CONFIG}_sim_tau-_{P}GeV_{INDEX}.edm4hep.root",
@@ -51,7 +51,7 @@ exec npsim \
 rule insert_tau_recon:
     input:
         SIM_FILE="sim_output/insert_tau/{DETECTOR_CONFIG}_sim_tau-_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/insert_tau/{DETECTOR_CONFIG}_rec_tau-_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/lfhcal/Snakefile
+++ b/benchmarks/lfhcal/Snakefile
@@ -8,7 +8,7 @@ def get_n_events(wildcards):
 rule lfhcal_sim:
     input:
         steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/lfhcal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
     log:
@@ -38,7 +38,7 @@ ddsim \
 rule lfhcal_recon:
     input:
         "sim_output/lfhcal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/lfhcal/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/nhcal_acceptance/Snakefile
+++ b/benchmarks/nhcal_acceptance/Snakefile
@@ -1,6 +1,6 @@
 rule nhcal_acceptance_simulate:
     input:
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/nhcal_acceptance/E{ENERGY}GeV/sim_{DETECTOR_CONFIG}.{INDEX}.edm4hep.root",
     params:

--- a/benchmarks/nhcal_basic_distribution/Snakefile
+++ b/benchmarks/nhcal_basic_distribution/Snakefile
@@ -1,6 +1,6 @@
 rule nhcal_basic_distribution_simulate:
     input:
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/nhcal_basic_distribution/E{ENERGY}GeV/sim_{DETECTOR_CONFIG}.{INDEX}.edm4hep.root",
     params:

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -1,7 +1,7 @@
 rule tracking_performance_sim:
     input:
         steering_file="EPIC/EVGEN/SINGLE/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.steer",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
@@ -43,7 +43,7 @@ exec ddsim \
 rule tracking_performance_recon:
     input:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/tracking_performance/{DETECTOR_CONFIG}/{PARTICLE}/{ENERGY}/{PHASE_SPACE}/{PARTICLE}_{ENERGY}_{PHASE_SPACE}.{INDEX}.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -22,7 +22,7 @@ rule trk_dis_compile:
 # Process the generated HepMC files through the simulation
 rule trk_dis_sim:
     input:
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4hep.root",
@@ -56,7 +56,7 @@ ddsim \
 rule trk_dis_reco:
     input:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/tracking_performances_dis/{DETECTOR_CONFIG}/pythia8NCDIS_{EBEAM}x{PBEAM}_minQ2={MINQ2}_beamEffects_xAngle=-0.025_hiDiv_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/zdc_lambda/Snakefile
+++ b/benchmarks/zdc_lambda/Snakefile
@@ -14,7 +14,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},0,"{output.GEN_FILE}",{params.P}
 rule zdc_lambda_simulate:
     input:
         GEN_FILE="sim_output/zdc_lambda/lambda_decay_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV_{INDEX}.edm4hep.root",
@@ -43,7 +43,7 @@ exec npsim \
 rule zdc_lambda_recon:
     input:
         SIM_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/zdc_lambda/{DETECTOR_CONFIG}_rec_lambda_dec_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/zdc_lyso/Snakefile
+++ b/benchmarks/zdc_lyso/Snakefile
@@ -23,7 +23,7 @@ root -l -b -q '{input.script}({params.num_events}, "{output.hepmcfile}", "{param
 rule zdc_lyso_sim:
     input:
         hepmcfile="data/{PARTICLE}_{BEAM_ENERGY}GeV_theta_{THETA_MIN}deg_thru_{THETA_MAX}deg.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         "sim_output/zdc_lyso/{DETECTOR_CONFIG}_{PARTICLE}_{BEAM_ENERGY}GeV_theta_{THETA_MIN}deg_thru_{THETA_MAX}deg.edm4hep.root",
@@ -52,7 +52,7 @@ exec npsim \
 rule zdc_lyso_reco:
     input:
         "sim_output/zdc_lyso/{DETECTOR_CONFIG}_{PARTICLE}_{BEAM_ENERGY}GeV_theta_{THETA_MIN}deg_thru_{THETA_MAX}deg.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/zdc_lyso/{DETECTOR_CONFIG}_{PARTICLE}_{BEAM_ENERGY}GeV_theta_{THETA_MIN}deg_thru_{THETA_MAX}deg.eicrecon.edm4eic.root",
     log:

--- a/benchmarks/zdc_neutron/Snakefile
+++ b/benchmarks/zdc_neutron/Snakefile
@@ -15,7 +15,7 @@ root -l -b -q '{input.script}({params.num_events}, 0, "{output.hepmcfile}")'
 rule zdc_neutron_sim:
     input:
         hepmcfile="sim_output/zdc_neutron/{DETECTOR_CONFIG}/fwd_neutrons.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/zdc_neutron/{DETECTOR_CONFIG}/fwd_neutrons.edm4hep.root",
     params:
@@ -37,7 +37,7 @@ exec npsim \
 rule zdc_neutron_reco:
     input:
         "sim_output/zdc_neutron/{DETECTOR_CONFIG}/fwd_neutrons.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         "sim_output/zdc_neutron/{DETECTOR_CONFIG}/fwd_neutrons.edm4eic.root",
     shell:

--- a/benchmarks/zdc_photon/Snakefile
+++ b/benchmarks/zdc_photon/Snakefile
@@ -17,7 +17,7 @@ root -l -b -q '{input.script}('{params.N_EVENTS}',"{output.GEN_FILE}", "gamma", 
 rule zdc_photon_simulate:
     input:
         GEN_FILE="sim_output/zdc_photon/zdc_photon_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/zdc_photon/{DETECTOR_CONFIG}_sim_zdc_photon_{P}GeV_{INDEX}.edm4hep.root",
@@ -46,7 +46,7 @@ exec npsim \
 rule zdc_photon_recon:
     input:
         SIM_FILE="sim_output/zdc_photon/{DETECTOR_CONFIG}_sim_zdc_photon_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/zdc_photon/{DETECTOR_CONFIG}_rec_zdc_photon_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/zdc_pi0/Snakefile
+++ b/benchmarks/zdc_pi0/Snakefile
@@ -15,7 +15,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},0,"{output.GEN_FILE}",{params.P}
 rule zdc_pi0_simulate:
     input:
         GEN_FILE="sim_output/zdc_pi0/zdc_pi0_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/zdc_pi0/{DETECTOR_CONFIG}_sim_zdc_pi0_{P}GeV_{INDEX}.edm4hep.root",
@@ -44,7 +44,7 @@ exec npsim \
 rule zdc_pi0_recon:
     input:
         SIM_FILE="sim_output/zdc_pi0/{DETECTOR_CONFIG}_sim_zdc_pi0_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/zdc_pi0/{DETECTOR_CONFIG}_rec_zdc_pi0_{P}GeV_{INDEX}.edm4eic.root",
     params:

--- a/benchmarks/zdc_sigma/Snakefile
+++ b/benchmarks/zdc_sigma/Snakefile
@@ -14,7 +14,7 @@ root -l -b -q '{input.script}({params.N_EVENTS},0,"{output.GEN_FILE}",{params.P}
 rule zdc_sigma_simulate:
     input:
         GEN_FILE="sim_output/zdc_sigma/sigma_decay_{P}GeV.hepmc",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
         geometry_lib=find_epic_libraries(),
     output:
         SIM_FILE="sim_output/zdc_sigma/{DETECTOR_CONFIG}_sim_sigma_dec_{P}GeV_{INDEX}.edm4hep.root",
@@ -43,7 +43,7 @@ exec npsim \
 rule zdc_sigma_recon:
     input:
         SIM_FILE="sim_output/zdc_sigma/{DETECTOR_CONFIG}_sim_sigma_dec_{P}GeV_{INDEX}.edm4hep.root",
-        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
+        warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
     output:
         REC_FILE="sim_output/zdc_sigma/{DETECTOR_CONFIG}_rec_sigma_dec_{P}GeV_{INDEX}.edm4eic.root",
     params:


### PR DESCRIPTION
I see unnecessary simulation re-ran due to updated warmup. E.g. job https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/5844320 starts with
```output
[Sun Jul  6 13:53:47 2025]
localrule org2py:
    input: /builds/EIC/benchmarks/detector_benchmarks/benchmarks/calo_pid/calo_pid.org, /builds/EIC/benchmarks/detector_benchmarks/benchmarks/common/org2py.awk (cached)
    output: benchmarks/calo_pid/calo_pid.py
    jobid: 405
    reason: Missing output files: benchmarks/calo_pid/calo_pid.py
    wildcards: NOTEBOOK=benchmarks/calo_pid/calo_pid
    resources: tmpdir=/tmp

[Sun Jul  6 13:53:47 2025]
Finished job 405.
1 of 406 steps (0.2%) done
Select jobs to execute...
Execute 1 jobs...

[Sun Jul  6 13:53:47 2025]
Job 4: Ensuring that calibrations/fieldmaps are available for epic_inner_detector
Reason: Missing output files: warmup/epic_inner_detector.edm4hep.root
```
results in a jobs being retriggered:
```output
reason: Input files updated by another job: warmup/epic_inner_detector.edm4hep.root
```

It's not clear how the warmup is retriggered in bench job. I could see, if simulation was cached, but reconstruction was not, then (after #181) this could be an issue. But in that case, shouldn't simulation be pulled from cache instead of recomputed? I don't understand, but fixing this should at least shorten the logs, and, possibly, allow us to understand the issue better.