### PR TITLE
treewide: revert from using 1 core to newly defined $MAX_CORES_PER_JOB

### DIFF
--- a/benchmarks/backgrounds/config.yml
+++ b/benchmarks/backgrounds/config.yml
@@ -5,7 +5,7 @@ sim:backgrounds:
     - mkdir -p $LOCAL_DATA_PATH/input
     - ln -s $LOCAL_DATA_PATH/input input
     - |
-      snakemake $SNAKEMAKE_FLAGS --cores 1 \
+      snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB \
         sim_output/$DETECTOR_CONFIG/backgrounds/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/electron/GETaLM1.0.0-1.0/10GeV/GETaLM1.0.0-1.0_ElectronBeamGas_10GeV_foam_emin10keV_run001.edm4hep.root \
         sim_output/$DETECTOR_CONFIG/backgrounds/EPIC/EVGEN/DIS/NC/10x100/minQ2=1/pythia8NCDIS_10x100_minQ2=1_beamEffects_xAngle=-0.025_hiDiv_1.edm4hep.root \
         sim_output/$DETECTOR_CONFIG/backgrounds/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/proton/pythia8.306-1.0/100GeV/pythia8.306-1.0_ProtonBeamGas_100GeV_run001.edm4hep.root
@@ -19,7 +19,7 @@ bench:backgrounds_emcal_backwards:
     - ln -s $LOCAL_DATA_PATH/input input
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backgrounds/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 backgrounds_ecal_backwards
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB backgrounds_ecal_backwards
 
 collect_results:backgrounds:
   extends: .det_benchmark

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -16,7 +16,7 @@ sim:backwards_ecal:
         ]
   script:
     - |
-      snakemake $SNAKEMAKE_FLAGS --cores 1 listing/backwards_ecal/local/${DETECTOR_CONFIG}/${PARTICLE}/${MOMENTUM}/130to177deg.lst
+      snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB listing/backwards_ecal/local/${DETECTOR_CONFIG}/${PARTICLE}/${MOMENTUM}/130to177deg.lst
 
 bench:backwards_ecal:
   extends: .det_benchmark
@@ -26,7 +26,7 @@ bench:backwards_ecal:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backwards_ecal/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/backwards_ecal/local
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/local
 
 bench:backwards_ecal_campaigns:
   extends: .det_benchmark
@@ -36,7 +36,7 @@ bench:backwards_ecal_campaigns:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backwards_ecal/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/backwards_ecal/24.10.1
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/24.10.1
 
 collect_results:backwards_ecal:
   extends: .det_benchmark

--- a/benchmarks/beamline/config.yml
+++ b/benchmarks/beamline/config.yml
@@ -3,7 +3,7 @@ sim:beamline:
   stage: simulate
   script:
     - |
-      snakemake $SNAKEMAKE_FLAGS --cores 1 \
+      snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB \
         sim_output/beamline/acceptanceTestlocal.edm4hep.root \
         sim_output/beamline/beamlineTestlocal.edm4hep.root
 
@@ -13,7 +13,7 @@ bench:beamline:
   needs:
     - ["sim:beamline"]
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 beamline_local
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB beamline_local
 
 collect_results:beamline:
   extends: .det_benchmark

--- a/benchmarks/calo_pid/config.yml
+++ b/benchmarks/calo_pid/config.yml
@@ -18,7 +18,7 @@ sim:calo_pid:
         ]
   script:
     - |
-      snakemake $SNAKEMAKE_FLAGS --cores 1 \
+      snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB \
         $(seq --format="sim_output/calo_pid/epic_inner_detector/${PARTICLE}/100MeVto20GeV/130to177deg/${PARTICLE}_100MeVto20GeV_130to177deg.%04.f.eicrecon.edm4eic.root" ${INDEX_RANGE})
 
 bench:calo_pid:

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -4,7 +4,7 @@ sim:ecal_gaps:
   script:
     - mkdir -p $LOCAL_DATA_PATH/input
     - ln -s $LOCAL_DATA_PATH/input input
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_inner_detector/ecal_gaps --omit-from ecal_gaps
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/epic_inner_detector/ecal_gaps --omit-from ecal_gaps
 
 bench:ecal_gaps:
   extends: .det_benchmark
@@ -15,7 +15,7 @@ bench:ecal_gaps:
     - ln -s $LOCAL_DATA_PATH/input input
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/ecal_gaps/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_inner_detector/ecal_gaps
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/epic_inner_detector/ecal_gaps
 
 collect_results:ecal_gaps:
   extends: .det_benchmark

--- a/benchmarks/insert_muon/config.yml
+++ b/benchmarks/insert_muon/config.yml
@@ -5,7 +5,7 @@ sim:insert_muon:
     matrix:
       - P: 50
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/insert_muon/epic_craterlake_sim_mu-_${P}GeV_{0,1,2,3,4}.edm4hep.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/insert_muon/epic_craterlake_sim_mu-_${P}GeV_{0,1,2,3,4}.edm4hep.root
   retry:
     max: 2
     when:

--- a/benchmarks/insert_neutron/config.yml
+++ b/benchmarks/insert_neutron/config.yml
@@ -11,7 +11,7 @@ sim:insert_neutron:
       - P: 70
       - P: 80
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/insert_neutron/epic_craterlake_rec_neutron_${P}GeV_{0,1,2,3,4}.edm4eic.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/insert_neutron/epic_craterlake_rec_neutron_${P}GeV_{0,1,2,3,4}.edm4eic.root
   retry:
     max: 2
     when:

--- a/benchmarks/insert_tau/config.yml
+++ b/benchmarks/insert_tau/config.yml
@@ -12,7 +12,7 @@ sim:insert_tau:
       - P: 100
   timeout: 1 hours
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/insert_tau/epic_craterlake_sim_tau-_${P}GeV_{0,1,2,3,4}.edm4hep.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/insert_tau/epic_craterlake_sim_tau-_${P}GeV_{0,1,2,3,4}.edm4hep.root
   retry:
     max: 2
     when:

--- a/benchmarks/lfhcal/config.yml
+++ b/benchmarks/lfhcal/config.yml
@@ -7,7 +7,7 @@ sim:lfhcal:
         MOMENTUM: ["500MeV", "1GeV", "2GeV", "5GeV", "10GeV", "20GeV"]
   script:
     - |
-      snakemake --cache --cores 1 \
+      snakemake --cache --cores $MAX_CORES_PER_JOB \
         sim_output/lfhcal/epic_craterlake/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.edm4eic.root
 
 bench:lfhcal:
@@ -16,7 +16,7 @@ bench:lfhcal:
   needs:
     - ["sim:lfhcal"]
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 lfhcal_local
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB lfhcal_local
 
 collect_results:lfhcal:
   extends: .det_benchmark

--- a/benchmarks/nhcal_acceptance/config.yml
+++ b/benchmarks/nhcal_acceptance/config.yml
@@ -6,7 +6,7 @@ sim:nhcal_acceptance:
       - ENERGY: ["1GeV", "5GeV", "10GeV"]
         INDEX_RANGE: ["0 4","5 9"]
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_acceptance/E${ENERGY}/sim_epic_backward_hcal_only.${INDEX}.edm4hep.root; done)
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_acceptance/E${ENERGY}/sim_epic_backward_hcal_only.${INDEX}.edm4hep.root; done)
 
 bench:nhcal_acceptance_analysis:
   extends: .det_benchmark

--- a/benchmarks/nhcal_basic_distribution/config.yml
+++ b/benchmarks/nhcal_basic_distribution/config.yml
@@ -6,7 +6,7 @@ sim:nhcal_basic_distribution:
       - ENERGY: ["0.5GeV", "0.7GeV", "1.0GeV", "2.0GeV", "5.0GeV"]
         INDEX_RANGE: ["0 4","5 9"]
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_basic_distribution/E${ENERGY}/sim_epic_backward_hcal_only.${INDEX}.edm4hep.root; done)
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_basic_distribution/E${ENERGY}/sim_epic_backward_hcal_only.${INDEX}.edm4hep.root; done)
 
 sim:nhcal_basic_distribution_full:
   extends: .det_benchmark
@@ -16,7 +16,7 @@ sim:nhcal_basic_distribution_full:
       - ENERGY: ["0.5GeV", "0.7GeV", "1.0GeV", "2.0GeV", "5.0GeV"]
         INDEX_RANGE: ["0 4","5 9"]
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_basic_distribution/E${ENERGY}/sim_epic_full.${INDEX}.edm4hep.root; done)
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_basic_distribution/E${ENERGY}/sim_epic_full.${INDEX}.edm4hep.root; done)
 
 bench:nhcal_basic_distribution_analysis:
   extends: .det_benchmark

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -18,7 +18,7 @@ bench:tracking_performance:
   needs:
     - ["sim:tracking_performance"]
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 tracking_performance_local
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB tracking_performance_local
 
 collect_results:tracking_performance:
   extends: .det_benchmark

--- a/benchmarks/tracking_performances_dis/config.yml
+++ b/benchmarks/tracking_performances_dis/config.yml
@@ -2,7 +2,7 @@ sim:tracking_performances_dis:
   extends: .det_benchmark
   stage: simulate
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/hists.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/hists.root
   retry:
     max: 2
     when:

--- a/benchmarks/zdc_lambda/config.yml
+++ b/benchmarks/zdc_lambda/config.yml
@@ -12,7 +12,7 @@ sim:zdc_lambda:
       - P: 250
       - P: 275
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/zdc_lambda/epic_zdc_sipm_on_tile_only_rec_lambda_dec_${P}GeV_{0,1,2,3,4}.edm4eic.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/zdc_lambda/epic_zdc_sipm_on_tile_only_rec_lambda_dec_${P}GeV_{0,1,2,3,4}.edm4eic.root
   retry:
     max: 2
     when:

--- a/benchmarks/zdc_neutron/config.yml
+++ b/benchmarks/zdc_neutron/config.yml
@@ -2,7 +2,7 @@ sim:zdc_neutron:
   extends: .det_benchmark
   stage: simulate
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/zdc_neutron/epic_craterlake/fwd_neutrons.edm4eic.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/zdc_neutron/epic_craterlake/fwd_neutrons.edm4eic.root
   retry:
     max: 2
     when:

--- a/benchmarks/zdc_photon/config.yml
+++ b/benchmarks/zdc_photon/config.yml
@@ -12,7 +12,7 @@ sim:zdc_photon:
       - P: 200
       - P: 275
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/zdc_photon/epic_zdc_sipm_on_tile_only_rec_zdc_photon_${P}GeV_{0,1,2,3,4}.edm4eic.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/zdc_photon/epic_zdc_sipm_on_tile_only_rec_zdc_photon_${P}GeV_{0,1,2,3,4}.edm4eic.root
   retry:
     max: 2
     when:

--- a/benchmarks/zdc_pi0/config.yml
+++ b/benchmarks/zdc_pi0/config.yml
@@ -9,7 +9,7 @@ sim:zdc_pi0:
       - P: 130
       - P: 160
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/zdc_pi0/epic_zdc_sipm_on_tile_only_rec_zdc_pi0_${P}GeV_{0,1,2,3,4}.edm4eic.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/zdc_pi0/epic_zdc_sipm_on_tile_only_rec_zdc_pi0_${P}GeV_{0,1,2,3,4}.edm4eic.root
   retry:
     max: 2
     when:

--- a/benchmarks/zdc_sigma/config.yml
+++ b/benchmarks/zdc_sigma/config.yml
@@ -12,7 +12,7 @@ sim:zdc_sigma:
       - P: 250
       - P: 275
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 sim_output/zdc_sigma/epic_zdc_sipm_on_tile_only_rec_sigma_dec_${P}GeV_{0,1,2,3,4}.edm4eic.root
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB sim_output/zdc_sigma/epic_zdc_sipm_on_tile_only_rec_sigma_dec_${P}GeV_{0,1,2,3,4}.edm4eic.root
   retry:
     max: 2
     when:


### PR DESCRIPTION
We now get job timeouts. Probably should go back to oversubscribing.