### PR TITLE
beamline: analyses load geometry, so they have to depend on warmup

### DIFF
--- a/benchmarks/beamline/Snakefile
+++ b/benchmarks/beamline/Snakefile
@@ -41,6 +41,7 @@ rule beamline_acceptance_sim:
 
 rule beamline_steering_analysis:
     params:
+        warmup="warmup/epic_ip6_extended.edm4hep.root",
         xml=os.getenv("DETECTOR_PATH")+"/epic_ip6_extended.xml",
     input:
         script=workflow.source_path("beamlineAnalysis.C"),
@@ -64,6 +65,7 @@ rule beamline_steering_analysis:
 
 rule beamline_acceptance_analysis:
     params:
+        warmup="warmup/epic_ip6_extended.edm4hep.root",
         xml=os.getenv("DETECTOR_PATH")+"/epic_ip6_extended.xml",
     input:
         script=workflow.source_path("acceptanceAnalysis.C"),


### PR DESCRIPTION
Mysterious failures in https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/5975884#L234 must be somehow related to calibrations loading.