### PR TITLE
.gitlab-ci.yml: add GITHUB_PR variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,9 @@ image: ${BENCHMARKS_REGISTRY}/${BENCHMARKS_CONTAINER}:${BENCHMARKS_TAG}
 variables:
   DETECTOR: epic
   DETECTOR_CONFIG: epic_craterlake
-  GITHUB_SHA: ''
+  GITHUB_PR: ''
   GITHUB_REPOSITORY: ''
+  GITHUB_SHA: ''
   SNAKEMAKE_FLAGS: '--cache'
 
 workflow:


### PR DESCRIPTION
We currently have following in our metadata:
```
GITHUB_REPOSITORY:
GITHUB_SHA:
GITHUB_PR: $GITHUB_PR
```