### PR TITLE
feat: add calo pid simulation for 45 to 135 deg

### DIFF
--- a/benchmarks/calo_pid/config.yml
+++ b/benchmarks/calo_pid/config.yml
@@ -4,6 +4,10 @@ sim:calo_pid:
   parallel:
     matrix:
       - PARTICLE: ["e-", "pi-"]
+        ANGLE: [
+          "45to135deg",
+          "130to177deg"
+        ]
         INDEX_RANGE: [
           "0 9",
           "10 19",
@@ -19,7 +23,7 @@ sim:calo_pid:
   script:
     - |
       snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB \
-        $(seq --format="sim_output/calo_pid/epic_inner_detector/${PARTICLE}/100MeVto20GeV/130to177deg/${PARTICLE}_100MeVto20GeV_130to177deg.%04.f.eicrecon.edm4eic.root" ${INDEX_RANGE})
+        $(seq --format="sim_output/calo_pid/epic_inner_detector/${PARTICLE}/100MeVto20GeV/${ANGLE}/${PARTICLE}_100MeVto20GeV_${ANGLE}.%04.f.eicrecon.edm4eic.root" ${INDEX_RANGE})
 
 bench:calo_pid:
   extends: .det_benchmark


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR is a first step to add a benchmark to generate trained ML models for e/pi separation in the BIC.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: BIC ML training)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
More simulations, but cached.