### PR TITLE
backwards_ecal,ecal_gaps,tracking_performances_dis,nhcal_basic_distribution_full: increase timeouts

### DIFF
--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -14,6 +14,7 @@ sim:backwards_ecal:
           "10GeV",
           "20GeV",
         ]
+  timeout: 4 hours
   script:
     - |
       snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB listing/backwards_ecal/local/${DETECTOR_CONFIG}/${PARTICLE}/${MOMENTUM}/130to177deg.lst

--- a/benchmarks/ecal_gaps/config.yml
+++ b/benchmarks/ecal_gaps/config.yml
@@ -1,6 +1,7 @@
 sim:ecal_gaps:
   extends: .det_benchmark
   stage: simulate
+  timeout: 4 hours
   script:
     - mkdir -p $LOCAL_DATA_PATH/input
     - ln -s $LOCAL_DATA_PATH/input input

--- a/benchmarks/nhcal_basic_distribution/config.yml
+++ b/benchmarks/nhcal_basic_distribution/config.yml
@@ -17,6 +17,7 @@ sim:nhcal_basic_distribution_full:
         INDEX_RANGE: ["0 4","5 9"]
       - ENERGY: ["5.0GeV"]
         INDEX_RANGE: ["0 3", "4 6", "7 9"]
+  timeout: 4 hours
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB $(for INDEX in $(seq -f '%02.0f' $INDEX_RANGE); do echo sim_output/nhcal_basic_distribution/E${ENERGY}/sim_epic_full.${INDEX}.edm4hep.root; done)
 

--- a/benchmarks/tracking_performances_dis/config.yml
+++ b/benchmarks/tracking_performances_dis/config.yml
@@ -1,6 +1,7 @@
 sim:tracking_performances_dis:
   extends: .det_benchmark
   stage: simulate
+  timeout: 4 hours
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/tracking_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/hists.root
   retry:


### PR DESCRIPTION
Looks like some relatively recent changes pushed these benchmarks over the timeout.