### PR TITLE
Revert beamline and lowq2_reconstruction to no caching for the time being

### DIFF
--- a/benchmarks/beamline/Snakefile
+++ b/benchmarks/beamline/Snakefile
@@ -11,7 +11,6 @@ rule beamline_steering_sim:
         macro=workflow.source_path("beamlineGPS.mac"),
     output:
         SIMOUTDIR+"beamlineTest{CAMPAIGN}.edm4hep.root",
-    cache: True
     shell:
         """
             exec npsim \

--- a/benchmarks/lowq2_reconstruction/Snakefile
+++ b/benchmarks/lowq2_reconstruction/Snakefile
@@ -13,7 +13,6 @@ rule filter_hepmc_for_training:
         script=workflow.source_path("filterHEPMC3.py"),        
     output:
         SIMOUTDIR+"Low-Q2_Training_Events.hepmc3.tree.root",
-    cache: True
     params:
         events="root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/SIDIS/pythia6-eic/1.0.0/18x275/q2_0to1/pythia_ep_noradcor_18x275_q2_0.000000001_1.0_run1.ab.hepmc3.tree.root",
     shell:
@@ -28,7 +27,6 @@ rule lowq2_training_sim:
         events=SIMOUTDIR+"Low-Q2_Training_Events.hepmc3.tree.root",      
     output:
         SIMOUTDIR+"Low-Q2_Training_SimEvents_{CAMPAIGN}.edm4hep.root",
-    cache: True
     shell:
         """
             exec npsim \

--- a/benchmarks/lowq2_reconstruction/filterHEPMC3.py
+++ b/benchmarks/lowq2_reconstruction/filterHEPMC3.py
@@ -8,11 +8,13 @@ import sys
 parser = argparse.ArgumentParser(description='Train a regression model for the Tagger.')
 parser.add_argument('--outFile', type=str, default="temp.hepmc3.tree.root", help='Path to the output file')
 parser.add_argument('--inFile', type=str, nargs='+', help='Path to the input files')
+parser.add_argument('--maxEvents', type=int, default=-1, help='Maximum number of events to process')
 
 args = parser.parse_args()
 
 input_file = args.inFile[0]   # Change to your input file
 output_file = args.outFile
+max_events = args.maxEvents
 
 # Initialize reader and writer
 reader = hm.deduce_reader(input_file)
@@ -25,7 +27,8 @@ if not writer:
     sys.exit(1)
 
 event = hm.GenEvent()
-while not reader.failed():
+event_number = 0
+while not reader.failed() and (max_events < 0 or event_number < max_events):
     reader.read_event(event)
     for p in list(event.particles()):
         if p.pid() != 11:
@@ -34,6 +37,7 @@ while not reader.failed():
     if any(p.pid() == 11 for p in event.particles()):
         writer.write_event(event)
     event.clear()
+    event_number += 1
 
 reader.close()
 writer.close()


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Removes the caching of the beamline and lowq2_reconstruction simulations for the time being so that I am sure they are running with the relevant geometry. A future PR will be placed once I fully understand what's triggering the unnecessary resimulation through snakemake or loading from an inappropriate cache.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
