### PR TITLE
femc_photon: Implement try-except for curve_fit errors

### DIFF
--- a/benchmarks/femc_photon/analysis/femc_photon_plots.py
+++ b/benchmarks/femc_photon/analysis/femc_photon_plots.py
@@ -131,7 +131,11 @@ for p in arrays_sim:
     sigma=np.sqrt(y[slc])+0.5*(y[slc]==0)
     p0=(100, p, 3)
 
-    coeff, var_matrix = curve_fit(fnc, list(bcs[slc]), list(y[slc]), p0=p0, sigma=list(sigma), maxfev=10000)
+    try:
+        coeff, var_matrix = curve_fit(fnc, list(bcs[slc]), list(y[slc]), p0=p0, sigma=list(sigma), maxfev=10000)
+    except RuntimeError as e:
+        print(e, bcs[slc], y[slc])
+        continue
     #res=np.abs(coeff[2]/coeff[1])
     if p==50:
         xx=np.linspace(15*p/20,22*p/20, 100)


### PR DESCRIPTION
Issue seen in https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/6606383
```
Traceback (most recent call last):
  File "/builds/EIC/benchmarks/detector_benchmarks/benchmarks/femc_photon/analysis/femc_photon_plots.py", line 134, in <module>
    coeff, var_matrix = curve_fit(fnc, list(bcs[slc]), list(y[slc]), p0=p0, sigma=list(sigma), maxfev=10000)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/local/lib/python3.12/site-packages/scipy/optimize/_minpack_py.py", line 1026, in curve_fit
    raise RuntimeError("Optimal parameters not found: " + errmsg)
RuntimeError: Optimal parameters not found: gtol=0.000000 is too small, func(x) is orthogonal to the columns of
  the Jacobian to machine precision.
```