### PR TITLE
Beamline - Allow detector volumes which are not cone segments for tracking

### DIFF
--- a/benchmarks/beamline/acceptanceAnalysis.C
+++ b/benchmarks/beamline/acceptanceAnalysis.C
@@ -19,7 +19,7 @@
 using RVecS       = ROOT::VecOps::RVec<string>;
 using RNode       = ROOT::RDF::RNode;
 
-int acceptanceAnalysis( TString inFile             = "/scratch/EIC/G4out/beamline/acceptanceTest.edm4hep.root",
+int acceptanceAnalysis( TString inFile             = "/home/simong/EIC/detector_benchmarks_anl/sim_output/beamline/acceptanceTestXS2.edm4hep.root",
                         TString outFile            = "output.root",
                         std::string compactName    = "/home/simong/EIC/epic/install/share/epic/epic_ip6_extended.xml",
                         TString beampipeCanvasName = "acceptance_in_beampipe.png",

--- a/benchmarks/beamline/beamlineAnalysis.C
+++ b/benchmarks/beamline/beamlineAnalysis.C
@@ -19,7 +19,7 @@
 using RVecS       = ROOT::VecOps::RVec<string>;
 using RNode       = ROOT::RDF::RNode;
 
-int beamlineAnalysis(   TString inFile          = "/scratch/EIC/G4out/beamline/beamlineTest.edm4hep.root",
+int beamlineAnalysis(   TString inFile          = "/home/simong/EIC/detector_benchmarks_anl/sim_output/beamline/acceptanceTestXS3.edm4hep.root",
                         TString outFile         = "output.root",
                         std::string compactName = "/home/simong/EIC/epic/install/share/epic/epic_ip6_extended.xml",
                         TString beamspotCanvasName = "beamspot_canvas.png",

--- a/benchmarks/beamline/shared_functions.h
+++ b/benchmarks/beamline/shared_functions.h
@@ -4,9 +4,11 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "DD4hep/VolumeManager.h"
+#include "DD4hep/DetElement.h"
 #include "TFile.h"
 
 using RVecHits = ROOT::VecOps::RVec<edm4hep::SimTrackerHitData>;
+using namespace dd4hep;
 
 //-----------------------------------------------------------------------------------------
 // Grab Component functor
@@ -183,4 +185,13 @@ TH1F* CreateFittedHistogram(const std::string& histName,
   hist->SetMarkerColor(kRed);
 
   return hist;
+}
+
+void printHierarchy(const DetElement& de, int level = 0) {
+  std::string indent(level * 2, ' ');
+  std::cout << indent << "- " << de.name() << " (ID: " << de.id() << ")\n";
+
+  for (const auto& [childName, child] : de.children()) {
+    printHierarchy(child, level + 1);
+  }
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Adapts the beamline benchmark for changes in the geometry which allow for the virtual planes along the beamline to have an arbitrary shape.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
