### PR TITLE
beamline,nhcal_acceptance,nhcal_basic_distribution: add missing simulation cache invalidation

### DIFF
--- a/benchmarks/beamline/Snakefile
+++ b/benchmarks/beamline/Snakefile
@@ -56,8 +56,12 @@ rule beamline_acceptance_sim:
     input:
         warmup="warmup/epic_ip6_extended.edm4hep.root",
         macro=workflow.source_path("acceptanceGPS.mac"),
+        geometry_lib=find_epic_libraries(),
     output:
         SIMOUTDIR+"acceptanceTest{CAMPAIGN}.edm4hep.root",
+    params:
+        DD4HEP_HASH=get_spack_package_hash("dd4hep"),
+        NPSIM_HASH=get_spack_package_hash("npsim"),
     cache: True
     shell:
         """

--- a/benchmarks/nhcal_acceptance/Snakefile
+++ b/benchmarks/nhcal_acceptance/Snakefile
@@ -1,6 +1,7 @@
 rule nhcal_acceptance_simulate:
     input:
         warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
+        geometry_lib=find_epic_libraries(),
     output:
         "sim_output/nhcal_acceptance/E{ENERGY}GeV/sim_{DETECTOR_CONFIG}.{INDEX}.edm4hep.root",
     params:

--- a/benchmarks/nhcal_basic_distribution/Snakefile
+++ b/benchmarks/nhcal_basic_distribution/Snakefile
@@ -1,6 +1,7 @@
 rule nhcal_basic_distribution_simulate:
     input:
         warmup=ancient("warmup/{DETECTOR_CONFIG}.edm4hep.root"),
+        geometry_lib=find_epic_libraries(),
     output:
         "sim_output/nhcal_basic_distribution/E{ENERGY}GeV/sim_{DETECTOR_CONFIG}.{INDEX}.edm4hep.root",
     params:


### PR DESCRIPTION
Using `cache: True` requires one to carefully avoid caching too much.