### PR TITLE
treewide: use 4 cores in ROOT::EnableImplicitMT(4)

### DIFF
--- a/benchmarks/b0_tracker/analysis/b0_tracker_hits.cxx
+++ b/benchmarks/b0_tracker/analysis/b0_tracker_hits.cxx
@@ -25,7 +25,7 @@ R__LOAD_LIBRARY(libfmt.so)
 
 void b0_tracker_hits(const char* fname = "./sim_output/sim_forward_protons.edm4hep.root"){
 
-  ROOT::EnableImplicitMT(); // Tell ROOT you want to go parallel
+  ROOT::EnableImplicitMT(4); // use 4 threads
   double degree = TMath::Pi()/180.0;
 
   TChain* t = new TChain("events");

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_energy_scan_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_energy_scan_analysis.cxx
@@ -51,7 +51,7 @@ void save_canvas(TCanvas* c, std::string var_label, std::string E_label, std::st
 std::tuple <double, double, double, double> extract_sampling_fraction_parameters(std::string particle_label, std::string E_label, dd4hep::Detector& detector)
 {
   std::string input_fname = fmt::format("sim_output/energy_scan/{}/sim_emcal_barrel_{}.edm4hep.root", E_label, particle_label);
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", input_fname);
 
   // Thrown Energy [GeV]

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_particles_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_particles_analysis.cxx
@@ -60,7 +60,7 @@ void emcal_barrel_particles_analysis(std::string particle_name = "electron", boo
   double fSam_img_mean_err;
   double fSam_scfi_mean_err;
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   std::string input_fname = fmt::format("sim_output/sim_emcal_barrel_{}.edm4hep.root", particle_name);
   ROOT::RDataFrame d0("events", input_fname);
 

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pi0_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pi0_analysis.cxx
@@ -45,7 +45,7 @@ void emcal_barrel_pi0_analysis(
   gStyle->SetPadLeftMargin(0.14);
   gStyle->SetPadRightMargin(0.14);
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", input_fname);
 
   // Sampling Fraction grabbed from json file

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx
@@ -66,7 +66,7 @@ void emcal_barrel_pion_rejection_analysis(
   gStyle->SetPadLeftMargin(0.14);
   gStyle->SetPadRightMargin(0.14);
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", {input_fname1, input_fname2});
 
   // Script requires EcalBarrelScFiHits

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pions_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pions_analysis.cxx
@@ -37,7 +37,7 @@ void emcal_barrel_pions_analysis(const char* input_fname = "sim_output/sim_emcal
   gStyle->SetPadLeftMargin(0.14);
   gStyle->SetPadRightMargin(0.14);
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", input_fname);
 
   // Sampling Fraction

--- a/benchmarks/beamline/acceptanceAnalysis.C
+++ b/benchmarks/beamline/acceptanceAnalysis.C
@@ -43,7 +43,7 @@ int acceptanceAnalysis( TString inFile             = "/home/simong/EIC/detector_
     int pass = 0;
 
     //Set implicit multi-threading
-    // ROOT::EnableImplicitMT();
+    // ROOT::EnableImplicitMT(4); // use 4 threads
        
     //Load the detector config
     dd4hep::Detector& detector = dd4hep::Detector::getInstance();

--- a/benchmarks/beamline/beamlineAnalysis.C
+++ b/benchmarks/beamline/beamlineAnalysis.C
@@ -44,7 +44,7 @@ int beamlineAnalysis(   TString inFile          = "/home/simong/EIC/detector_ben
     gStyle->SetOptStat(0);
 
     //Set implicit multi-threading
-    ROOT::EnableImplicitMT();
+    ROOT::EnableImplicitMT(4); // use 4 threads
        
     int pass = 0;
 

--- a/benchmarks/pid/scripts/drich_analysis.cxx
+++ b/benchmarks/pid/scripts/drich_analysis.cxx
@@ -33,7 +33,7 @@ void drich_analysis(const char* input_fname = "sim_output/sim_pid_forward_e-_5Ge
   gStyle->SetPadLeftMargin(0.14);
   gStyle->SetPadRightMargin(0.14);
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", input_fname);
 
   // Define variables

--- a/benchmarks/pid/scripts/mrich_analysis.cxx
+++ b/benchmarks/pid/scripts/mrich_analysis.cxx
@@ -33,7 +33,7 @@ void mrich_analysis(const char* input_fname = "sim_output/sim_pid_backward_e-_5G
   gStyle->SetPadLeftMargin(0.14);
   gStyle->SetPadRightMargin(0.14);
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", input_fname);
 
   // Number of hits

--- a/benchmarks/tracking_detectors/analysis/sim_track_hits.cxx
+++ b/benchmarks/tracking_detectors/analysis/sim_track_hits.cxx
@@ -96,7 +96,7 @@ ROOT::RDF::RNode add_subsystems(ROOT::RDF::RNode df, std::vector<std::pair<std::
 
 int sim_track_hits(const char* fname = "sim_track_hits.edm4hep.root") {
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame df("events", fname);
 
   // detect detector setup

--- a/benchmarks/zdc/scripts/analysis_zdc_particles.cxx
+++ b/benchmarks/zdc/scripts/analysis_zdc_particles.cxx
@@ -36,7 +36,7 @@ void analysis_zdc_particles(
   gStyle->SetPadLeftMargin(0.14);
   gStyle->SetPadRightMargin(0.14);
 
-  ROOT::EnableImplicitMT();
+  ROOT::EnableImplicitMT(4); // use 4 threads
   ROOT::RDataFrame d0("events", input_fname);
 
   // Thrown Energy [GeV]

--- a/benchmarks/zdc/simple_checking.cxx
+++ b/benchmarks/zdc/simple_checking.cxx
@@ -31,7 +31,7 @@ R__LOAD_LIBRARY(libDDG4IO.so)
 
 void simple_checking(const char* fname = "sim_output/output_zdc_photons.edm4hep.root"){
 std::cout << "testing 1\n";
-  ROOT::EnableImplicitMT(); // Tell ROOT you want to go parallel
+  ROOT::EnableImplicitMT(4); // use 4 threads
   //using namespace lcio2;
   double degree = TMath::Pi()/180.0;
 


### PR DESCRIPTION
This potentially ignores what's on the user's machine, but at least doesn't book 256 threads on eicweb.