### PR TITLE
emcal_barrel_pion_rejection_analysis: guard against bad fit

### DIFF
--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx
@@ -407,6 +407,9 @@ void emcal_barrel_pion_rejection_analysis(
         double* res = gaus->GetParameters();
         cutEEta += fmt::format("&&EDep6OverP>={}", res[1] - 2.0*res[2]);
         cutEEta += fmt::format("&&EDep6OverP<{})||",res[1] + 3.0*res[2]);
+      } else {
+        cutEEta += ")||"; // Close the eta condition without EDep6OverP
+        std::cerr << "Warning: Gaussian fit failed for E bin " << i << ", eta bin " << j << std::endl;
       }
 
       hp->GetYaxis()->SetTitleOffset(1.4);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a guard against a nullptr when the gaus fit fails.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/6818908#L4409)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
