### PR TITLE
fix: explicitly compile macros that include edm4hep headers (3/*)

### DIFF
--- a/benchmarks/lowq2_reconstruction/Snakefile
+++ b/benchmarks/lowq2_reconstruction/Snakefile
@@ -97,7 +97,7 @@ rule lowq2_steering_reconstruction_preparation:
         rootfile=ANALYSISDIR+"Low-Q2_Steering_Reconstruction_Data{CAMPAIGN}.root",
     shell:
         """
-        root -l -b -q '{input.script}("{input.data}", "{output.rootfile}",18.0)'
+        root -l -b -q '{input.script}+("{input.data}", "{output.rootfile}",18.0)'
         """
 
 # Trains a regression model to predict the MCParticle momentum from the lowq2 tagger tracker hits.
@@ -150,7 +150,7 @@ rule lowq2_reconstruction_particles_test:
         resolutionGraphsCanvas=ANALYSISDIR+"{STAGE}_resolution_graphs_{CAMPAIGN}.png",
     shell:
         """
-        root -l -b -q '{input.script}("{input.data}", 18, "{output.rootfile}", "{output.momentumCanvas}", "{output.energyThetaPhiCanvas}", "{output.relationCanvas}", "{output.resolutionGraphsCanvas}")'
+        root -l -b -q '{input.script}+("{input.data}", 18, "{output.rootfile}", "{output.momentumCanvas}", "{output.energyThetaPhiCanvas}", "{output.relationCanvas}", "{output.resolutionGraphsCanvas}")'
         """
 
 # Check the resloutions and offsets are within tollerance
@@ -162,7 +162,7 @@ rule lowq2_reconstruction_particles_check:
         jsonfile=ANALYSISDIR+"Low-Q2_{STAGE}_Resolution_Results_{CAMPAIGN}.json"
     shell:
         """
-        root -l -b -q '{input.script}("{input.rootfile}", "{output.jsonfile}")'
+        root -l -b -q '{input.script}+("{input.rootfile}", "{output.jsonfile}")'
         """
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR modifies two benchmarks to use explicit macro compilation (*.cxx+) to get around a bug when using podio-1.6.

This is applied only to the macros that are affected by the bug.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/6882165)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.