### PR TITLE
Increase verbosity level for warmup_run

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -109,6 +109,7 @@ rule warmup_run:
     shell: """
 set -m # monitor mode to prevent lingering processes
 exec ddsim \
+  -v VERBOSE \
   --runType batch \
   --numberOfEvents 1 \
   --compactFile "$DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml" \


### PR DESCRIPTION
We have epic geometry construction often exiting with an error code, but without any message on CI. This should help to start debugging this behaviour.