### PR TITLE
Add ROOT import to filterHEPMC3.py

### DIFF
--- a/benchmarks/lowq2_reconstruction/filterHEPMC3.py
+++ b/benchmarks/lowq2_reconstruction/filterHEPMC3.py
@@ -1,4 +1,4 @@
-import ROOT
+import ROOT  # noqa: F401; loads core libraries required by pyhepmc3
 from pyHepMC3 import HepMC3 as hm
 from pyHepMC3.rootIO import HepMC3 as hmrootIO
 import argparse


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds an explicit `import ROOT` before the use of the HepMC3 (incl. rootIO) functionality. This appears to be required for ROOT 6.38.00 (https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/6911468#L1101).

I'm not entirely happy by my lack of understanding of why this is necessary...

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/6911468#L1101)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.