### PR TITLE
backwards_ecal: 24.10.1 -> 25.10.4

### DIFF
--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -37,7 +37,7 @@ bench:backwards_ecal_campaigns:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backwards_ecal/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/24.10.1
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/25.10.4
 
 collect_results:backwards_ecal:
   extends: .det_benchmark


### PR DESCRIPTION
Switch from preTDR 1.0 campaign to preTDR 2.x campaign.