### PR TITLE
BUGFIX: Snakefile: correct the package hashing

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -23,7 +23,7 @@ def get_spack_package_hash(package_name):
     import json
     try:
         ver_info = json.loads(subprocess.check_output(["spack", "find", "--json", package_name]))
-        return ver_info[0]["package_hash"]
+        return ver_info[0]["hash"]
     except FileNotFoundError as e:
         logger.warning("Spack is not installed")
         return ""


### PR DESCRIPTION
It appears `package_hash` may be a hash of only the python source code, not the merkle tree one, like I thought. This probably lead to some false positive cache hits during some container updates. Namely, this may have caused us to miss the https://github.com/eic/EICrecon/issues/2334