### PR TITLE
tracking_performance: run epic_craterlake_tracking_2Dstrip simulation

### DIFF
--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -8,9 +8,9 @@ sim:tracking_performance:
   script:
     - |
       snakemake $SNAKEMAKE_FLAGS --cores 2 \
-        sim_output/tracking_performance/epic_craterlake_tracking_2Dstrip/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.edm4eic.root \
-        sim_output/tracking_performance/epic_craterlake_tracking_2Dstrip/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.edm4eic.root \
-        sim_output/tracking_performance/epic_craterlake_tracking_2Dstrip/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.edm4eic.root \
+        sim_output/tracking_performance/epic_craterlake_tracking_2DStrip/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.edm4eic.root \
+        sim_output/tracking_performance/epic_craterlake_tracking_2DStrip/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.edm4eic.root \
+        sim_output/tracking_performance/epic_craterlake_tracking_2DStrip/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.edm4eic.root

--- a/benchmarks/tracking_performances/config.yml
+++ b/benchmarks/tracking_performances/config.yml
@@ -7,7 +7,10 @@ sim:tracking_performance:
         MOMENTUM: ["500MeV", "1GeV", "2GeV", "5GeV", "10GeV", "20GeV"]
   script:
     - |
-      snakemake $SNAKEMAKE_FLAGS --cores 1 \
+      snakemake $SNAKEMAKE_FLAGS --cores 2 \
+        sim_output/tracking_performance/epic_craterlake_tracking_2Dstrip/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.edm4eic.root \
+        sim_output/tracking_performance/epic_craterlake_tracking_2Dstrip/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.edm4eic.root \
+        sim_output/tracking_performance/epic_craterlake_tracking_2Dstrip/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/3to50deg/${PARTICLE}_${MOMENTUM}_3to50deg.0000.eicrecon.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/45to135deg/${PARTICLE}_${MOMENTUM}_45to135deg.0000.eicrecon.edm4eic.root \
         sim_output/tracking_performance/epic_craterlake_tracking_only/${PARTICLE}/${MOMENTUM}/130to177deg/${PARTICLE}_${MOMENTUM}_130to177deg.0000.eicrecon.edm4eic.root


### PR DESCRIPTION
The full analysis is not flexible to pick this, but we can at least simulate and reconstruct.