### PR TITLE
Add campaign performance metrics benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,8 @@ include:
   - local: 'benchmarks/femc_pi0/config.yml'
   - local: 'benchmarks/nhcal_acceptance/config.yml'
   - local: 'benchmarks/nhcal_basic_distribution/config.yml'
-  
+  - local: 'benchmarks/campaign_performance_metrics/config.yml'
+
 deploy_results:
   allow_failure: true
   stage: deploy
@@ -194,6 +195,7 @@ deploy_results:
     - "collect_results:femc_pi0"
     - "collect_results:nhcal_acceptance"
     - "collect_results:nhcal_basic_distribution"
+    - "collect_results:campaign_performance_metrics"
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 results/metadata.json
     - find results -print | sort | tee summary.txt

--- a/Snakefile
+++ b/Snakefile
@@ -71,6 +71,7 @@ include: "benchmarks/femc_photon/Snakefile"
 include: "benchmarks/femc_pi0/Snakefile"
 include: "benchmarks/nhcal_acceptance/Snakefile"
 include: "benchmarks/nhcal_basic_distribution/Snakefile"
+include: "benchmarks/campaign_performance_metrics/Snakefile"
 
 use_s3 = config["remote_provider"].lower() == "s3"
 use_xrootd = config["remote_provider"].lower() == "xrootd"

--- a/benchmarks/campaign_performance_metrics/Snakefile
+++ b/benchmarks/campaign_performance_metrics/Snakefile
@@ -1,0 +1,87 @@
+import os
+
+CAMPAIGN_PERF_METRICS_DIR = "benchmarks/campaign_performance_metrics"
+
+CAMPAIGN_PERF_SAMPLE = int(os.environ.get("CAMPAIGN_PERF_SAMPLE", "5"))
+CAMPAIGN_PERF_SEED = int(os.environ.get("CAMPAIGN_PERF_SEED", "42"))
+
+
+checkpoint campaign_perf_discover:
+    """Discover SINGLES datasets for the campaign via Rucio."""
+    output:
+        datasets="sim_output/campaign_performance_metrics/{CAMPAIGN}/datasets.txt",
+    params:
+        script=f"{CAMPAIGN_PERF_METRICS_DIR}/discover_datasets.py",
+        CAMPAIGN=lambda wildcards: wildcards.CAMPAIGN,
+    shell:
+        """
+mkdir -p $(dirname {output.datasets})
+python3 {params.script} \
+    --campaign {params.CAMPAIGN} \
+    --output {output.datasets}
+"""
+
+
+rule campaign_perf_collect_dataset:
+    """Collect PRMON data for a single dataset (parallelized by INDEX)."""
+    input:
+        datasets="sim_output/campaign_performance_metrics/{CAMPAIGN}/datasets.txt",
+    output:
+        json="sim_output/campaign_performance_metrics/{CAMPAIGN}/collected/dataset_{INDEX}.json",
+    params:
+        script=f"{CAMPAIGN_PERF_METRICS_DIR}/collect_dataset.py",
+        sample=CAMPAIGN_PERF_SAMPLE,
+        seed=CAMPAIGN_PERF_SEED,
+        INDEX=lambda wildcards: wildcards.INDEX,
+    wildcard_constraints:
+        INDEX=r"\d+",
+    shell:
+        """
+mkdir -p $(dirname {output.json})
+DATASET=$(sed -n '{params.INDEX}p' {input.datasets})
+if [ -z "$DATASET" ]; then
+    echo '[ERROR] No dataset at line {params.INDEX} in {input.datasets}' >&2
+    exit 1
+fi
+python3 {params.script} \
+    --dataset "$DATASET" \
+    --sample {params.sample} \
+    --seed {params.seed} \
+    --output {output.json}
+"""
+
+
+def campaign_perf_collected_jsons(wildcards):
+    """
+    After the checkpoint resolves, read the datasets file to determine
+    how many collection jobs are needed (one per line).
+    """
+    datasets_file = checkpoints.campaign_perf_discover.get(
+        CAMPAIGN=wildcards.CAMPAIGN,
+    ).output.datasets
+    with open(datasets_file) as f:
+        n_datasets = sum(1 for line in f if line.strip())
+    return expand(
+        "sim_output/campaign_performance_metrics/{CAMPAIGN}/collected/dataset_{INDEX}.json",
+        CAMPAIGN=wildcards.CAMPAIGN,
+        INDEX=range(1, n_datasets + 1),  # sed is 1-indexed
+    )
+
+
+rule campaign_perf_plot:
+    """Aggregate all per-dataset JSONs and produce histogram plots."""
+    input:
+        jsons=campaign_perf_collected_jsons,
+    output:
+        results_dir=directory("results/campaign_performance_metrics/{CAMPAIGN}"),
+    params:
+        script=f"{CAMPAIGN_PERF_METRICS_DIR}/plot_singles_aggregate.py",
+        CAMPAIGN=lambda wildcards: wildcards.CAMPAIGN,
+    shell:
+        """
+mkdir -p {output.results_dir}
+python3 {params.script} \
+    --campaign {params.CAMPAIGN} \
+    --output-dir {output.results_dir} \
+    {input.jsons}
+"""

--- a/benchmarks/campaign_performance_metrics/Snakefile
+++ b/benchmarks/campaign_performance_metrics/Snakefile
@@ -51,6 +51,17 @@ python3 {params.script} \
 """
 
 
+rule campaign_perf_campaigns:
+    input:
+        expand(
+            "results/campaign_performance_metrics/{CAMPAIGN}",
+            CAMPAIGN=[
+                "26.03.0",
+                "26.03.1",
+            ],
+        )
+
+
 def campaign_perf_collected_jsons(wildcards):
     """
     After the checkpoint resolves, read the datasets file to determine

--- a/benchmarks/campaign_performance_metrics/collect_dataset.py
+++ b/benchmarks/campaign_performance_metrics/collect_dataset.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Collect PRMON data for a single Rucio dataset and write results as JSON.
+
+Designed to be called by Snakemake as an independent job per dataset,
+enabling parallel data collection across datasets.
+
+Usage:
+    python3 collect_dataset.py \
+        --dataset "epic:/RECO/26.03.0/.../SINGLE/..." \
+        --sample 5 --seed 42 \
+        --output collected/dataset_0.json
+"""
+
+import argparse
+import csv
+import io
+import json
+import random
+import re
+import subprocess
+import sys
+import tarfile
+from collections import defaultdict
+
+XROOT_BASE = "root://dtn-eic.jlab.org"
+RUCIO_PREFIX = "epic:/RECO"
+LOG_PREFIX = "/work/eic3/EPIC/LOGS/LOG"
+
+STEPS = ["npsim", "eicrecon"]
+
+
+# ── Path conversion ──────────────────────────────────────────────────────────
+
+def rucio_to_log_dir(rucio_ds):
+    ds = rucio_ds.strip()
+    if not ds.startswith(RUCIO_PREFIX):
+        raise ValueError(
+            f"Dataset does not start with '{RUCIO_PREFIX}': {ds!r}"
+        )
+    return LOG_PREFIX + ds[len(RUCIO_PREFIX):]
+
+
+# ── XRootD helpers ───────────────────────────────────────────────────────────
+
+def xrdfs_ls(remote_dir):
+    result = subprocess.run(
+        ["xrdfs", XROOT_BASE, "ls", remote_dir],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [l.strip() for l in result.stdout.splitlines() if l.strip()]
+
+
+def collect_tarballs(log_dir):
+    tarballs = []
+    top_entries = xrdfs_ls(log_dir)
+    for entry in top_entries:
+        if entry.endswith(".log.tar.gz"):
+            tarballs.append(entry)
+        else:
+            for sub in xrdfs_ls(entry):
+                if sub.endswith(".log.tar.gz"):
+                    tarballs.append(sub)
+    return tarballs
+
+
+def stream_tarball_bytes(remote_path):
+    url = f"{XROOT_BASE}/{remote_path}"
+    result = subprocess.run(["xrdcp", "--silent", url, "-"],
+                            capture_output=True)
+    return result.stdout if result.returncode == 0 else None
+
+
+# ── Parsing ──────────────────────────────────────────────────────────────────
+
+def parse_prmon_txt(content_bytes):
+    text = content_bytes.decode("utf-8", errors="replace")
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    rows = list(reader)
+    if not rows:
+        return None
+    columns = defaultdict(list)
+    for row in rows:
+        for k, v in row.items():
+            if k and k != "Time":
+                try:
+                    columns[k].append(float(v))
+                except (ValueError, TypeError):
+                    pass
+    summary = {"n_records": len(rows)}
+    for k, vals in columns.items():
+        if vals:
+            summary[f"{k}_max"] = max(vals)
+            summary[f"{k}_mean"] = sum(vals) / len(vals)
+    return summary
+
+
+def parse_nevents_from_log(log_bytes):
+    text = log_bytes.decode("utf-8", errors="replace")
+    m = re.search(
+        r"Finished run \d+ after \d+ events \((\d+) events in total\)", text
+    )
+    if m:
+        return int(m.group(1))
+    m = re.search(r'with (\d+) events \(format', text)
+    if m:
+        return int(m.group(1))
+    matches = re.findall(r"Status:\s+(\d+) events processed", text)
+    if matches:
+        return max(int(x) for x in matches)
+    return None
+
+
+def extract_prmon_from_bytes(tarball_bytes):
+    results = {}
+    file_contents = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes),
+                          mode="r:gz") as tf:
+            for member in tf.getmembers():
+                f = tf.extractfile(member)
+                if f:
+                    file_contents[member.name] = f.read()
+    except Exception as e:
+        print(f"    [ERROR] {e}", file=sys.stderr)
+        return results
+
+    for step in STEPS:
+        prmon = next(
+            (c for n, c in file_contents.items()
+             if f".{step}.prmon.txt" in n),
+            None,
+        )
+        if prmon is None:
+            continue
+        summary = parse_prmon_txt(prmon)
+        if summary is None:
+            continue
+        log = next(
+            (c for n, c in file_contents.items() if f".{step}.log" in n),
+            None,
+        )
+        if log:
+            n_ev = parse_nevents_from_log(log)
+            if n_ev is not None:
+                summary["n_events"] = n_ev
+        results[step] = summary
+
+    return results
+
+
+# ── Data collection ──────────────────────────────────────────────────────────
+
+def collect_data_for_dataset(rucio_ds, sample_size):
+    log_dir = rucio_to_log_dir(rucio_ds)
+    tarballs = collect_tarballs(log_dir)
+    n = min(sample_size, len(tarballs))
+
+    if not tarballs:
+        print(f"    [WARN] No tarballs found in {log_dir}", file=sys.stderr)
+        return {step: [] for step in STEPS}
+
+    print(f"    Found {len(tarballs)} tarballs, sampling {n}",
+          file=sys.stderr)
+    sample = random.sample(tarballs, n)
+    step_summaries = {step: [] for step in STEPS}
+
+    for i, remote_path in enumerate(sample, 1):
+        basename = remote_path.split("/")[-1]
+        print(f"    [{i:2d}/{n}] {basename[:65]} ... ",
+              end="", flush=True, file=sys.stderr)
+        data = stream_tarball_bytes(remote_path)
+        if data is None:
+            print("FAILED", file=sys.stderr)
+            continue
+        results = extract_prmon_from_bytes(data)
+        for step in STEPS:
+            if step in results:
+                step_summaries[step].append(results[step])
+        found = [s for s in STEPS if s in results]
+        print(f"ok ({', '.join(found)})", file=sys.stderr)
+
+    return step_summaries
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect PRMON data for a single Rucio dataset.",
+    )
+    parser.add_argument("--dataset", required=True,
+                        help="Rucio dataset DID (epic:/RECO/...)")
+    parser.add_argument("--sample", type=int, default=5,
+                        help="Number of jobs to sample (default: 5)")
+    parser.add_argument("--seed", type=int, default=42,
+                        help="Random seed (default: 42)")
+    parser.add_argument("--output", required=True,
+                        help="Output JSON file path")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    short = args.dataset.replace(RUCIO_PREFIX + "/", "")
+    print(f"Collecting data for: {short}", file=sys.stderr)
+
+    step_summaries = collect_data_for_dataset(args.dataset, args.sample)
+
+    result = {
+        "dataset": args.dataset,
+        "sample_size": args.sample,
+        "seed": args.seed,
+        "data": step_summaries,
+    }
+
+    with open(args.output, "w") as f:
+        json.dump(result, f, indent=2)
+
+    for step in STEPS:
+        n = len(step_summaries[step])
+        print(f"    {step}: {n} jobs collected", file=sys.stderr)
+
+    print(f"Written to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/campaign_performance_metrics/config.yml
+++ b/benchmarks/campaign_performance_metrics/config.yml
@@ -1,0 +1,18 @@
+bench:campaign_performance_metrics:
+  extends: .det_benchmark
+  stage: benchmarks
+  script:
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB
+        results/campaign_performance_metrics/${BENCHMARKS_TAG:-local}
+
+collect_results:campaign_performance_metrics:
+  extends: .det_benchmark
+  stage: collect
+  needs:
+    - "bench:campaign_performance_metrics"
+  when: always
+  script:
+    - mv results{,_save}/
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output
+        results/campaign_performance_metrics/${BENCHMARKS_TAG:-local}
+    - mv results{_save,}/

--- a/benchmarks/campaign_performance_metrics/config.yml
+++ b/benchmarks/campaign_performance_metrics/config.yml
@@ -2,8 +2,7 @@ bench:campaign_performance_metrics:
   extends: .det_benchmark
   stage: benchmarks
   script:
-    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB
-        results/campaign_performance_metrics/${BENCHMARKS_TAG:-local}
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB campaign_perf_campaigns
 
 collect_results:campaign_performance_metrics:
   extends: .det_benchmark
@@ -13,6 +12,5 @@ collect_results:campaign_performance_metrics:
   when: always
   script:
     - mv results{,_save}/
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output
-        results/campaign_performance_metrics/${BENCHMARKS_TAG:-local}
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 --delete-all-output campaign_perf_campaigns
     - mv results{_save,}/

--- a/benchmarks/campaign_performance_metrics/discover_datasets.py
+++ b/benchmarks/campaign_performance_metrics/discover_datasets.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Discover Rucio SINGLES datasets for a given EPIC campaign.
+
+Writes one dataset DID per line to stdout (or a file via --output).
+
+Usage:
+    python3 discover_datasets.py --campaign 26.03.0
+    python3 discover_datasets.py --campaign 26.03.0 --output datasets.txt
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+RUCIO_SCOPE = "epic"
+RUCIO_PREFIX = "epic:/RECO"
+
+
+def rucio_list_singles(campaign):
+    pattern = f"{RUCIO_SCOPE}:/RECO/*{campaign}*SINGLE*"
+    print(f"Running: rucio list-dids --filter type=DATASET '{pattern}'",
+          file=sys.stderr)
+    result = subprocess.run(
+        ["rucio", "list-dids", "--filter", "type=DATASET", pattern],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"[ERROR] rucio list-dids failed:\n{result.stderr.strip()}",
+              file=sys.stderr)
+        return []
+
+    datasets = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        m = re.search(r"(epic:/RECO/\S+)", line)
+        if m:
+            did = m.group(1).rstrip("|").strip()
+            if "SINGLE" in did.upper() and campaign in did:
+                datasets.append(did)
+
+    return sorted(set(datasets))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Discover SINGLES datasets for an EPIC campaign.",
+    )
+    parser.add_argument("--campaign", required=True,
+                        help="Campaign string to match (e.g. '26.03.0')")
+    parser.add_argument("--output", default=None,
+                        help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    datasets = rucio_list_singles(args.campaign)
+
+    if not datasets:
+        print("[ERROR] No matching datasets found.", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"Found {len(datasets)} dataset(s)", file=sys.stderr)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            for ds in datasets:
+                f.write(ds + "\n")
+        print(f"Written to {args.output}", file=sys.stderr)
+    else:
+        for ds in datasets:
+            print(ds)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/campaign_performance_metrics/plot_prmon.py
+++ b/benchmarks/campaign_performance_metrics/plot_prmon.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+Compare PRMON resource usage between two Rucio RECO datasets.
+
+Rucio dataset names are converted to XRootD LOG paths by replacing the prefix:
+    epic:/RECO  ->  /work/eic3/EPIC/LOGS/LOG
+
+Usage:
+    python3 plot_prmon.py \\
+        --ds1 "epic:/RECO/26.03.0/epic_craterlake/Bkg_Exact1S_2us/GoldCt/10um/DIS/NC/10x100/minQ2=1" \\
+        --ds2 "epic:/RECO/25.12.0/epic_craterlake/Bkg_Exactly1SignalPer2usFrame/GoldCoating/10um/DIS/NC/10x100/minQ2=1" \\
+        [--label1 "26.03.0"] [--label2 "25.12.0"] [--sample 20]
+"""
+
+import argparse
+import subprocess
+import random
+import tarfile
+import io
+import csv
+import re
+from collections import defaultdict
+from datetime import datetime
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+XROOT_BASE   = "root://dtn-eic.jlab.org"
+RUCIO_PREFIX = "epic:/RECO"
+LOG_PREFIX   = "/work/eic3/EPIC/LOGS/LOG"
+
+STEPS = ["npsim", "eicrecon"]
+
+PLOT_METRICS = [
+    ("rss",   "Peak RSS Memory", "MB", 1/1024),
+    ("vmem",  "Peak Vmem",       "MB", 1/1024),
+    ("wtime", "Wall Time",       "s",  1),
+    ("utime", "CPU Time (user)", "s",  1),
+]
+
+COLORS = ["#4C72B0", "#DD8452", "#55A868", "#C44E52"]
+
+
+# ── Path conversion ──────────────────────────────────────────────────────────
+
+def rucio_to_log_dir(rucio_ds):
+    """Convert a Rucio dataset name to an XRootD LOG directory path."""
+    ds = rucio_ds.strip()
+    if not ds.startswith(RUCIO_PREFIX):
+        raise ValueError(
+            f"Dataset does not start with '{RUCIO_PREFIX}': {ds!r}"
+        )
+    return LOG_PREFIX + ds[len(RUCIO_PREFIX):]
+
+
+# ── XRootD helpers ───────────────────────────────────────────────────────────
+
+def xrdfs_ls(remote_dir):
+    result = subprocess.run(
+        ["xrdfs", XROOT_BASE, "ls", remote_dir],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return []
+    return [l.strip() for l in result.stdout.splitlines() if l.strip()]
+
+
+def collect_tarballs(log_dir):
+    """
+    The LOG dir may be structured as:
+      log_dir/                     <- tarballs directly here, OR
+      log_dir/minQ2=*/             <- one subdir level, OR
+      log_dir/minQ2=*/             <- already included in log_dir
+    Walk up to two levels to find *.log.tar.gz files.
+    """
+    tarballs = []
+    top_entries = xrdfs_ls(log_dir)
+    for entry in top_entries:
+        if entry.endswith(".log.tar.gz"):
+            tarballs.append(entry)          # flat layout
+        else:
+            for sub in xrdfs_ls(entry):     # one subdir level
+                if sub.endswith(".log.tar.gz"):
+                    tarballs.append(sub)
+    return tarballs
+
+
+def stream_tarball_bytes(remote_path):
+    url = f"{XROOT_BASE}/{remote_path}"
+    result = subprocess.run(["xrdcp", "--silent", url, "-"], capture_output=True)
+    return result.stdout if result.returncode == 0 else None
+
+
+# ── Parsing ──────────────────────────────────────────────────────────────────
+
+def parse_prmon_txt(content_bytes):
+    text = content_bytes.decode("utf-8", errors="replace")
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    rows = list(reader)
+    if not rows:
+        return None
+    columns = defaultdict(list)
+    for row in rows:
+        for k, v in row.items():
+            if k and k != "Time":
+                try:
+                    columns[k].append(float(v))
+                except (ValueError, TypeError):
+                    pass
+    summary = {"n_records": len(rows)}
+    for k, vals in columns.items():
+        if vals:
+            summary[f"{k}_max"]  = max(vals)
+            summary[f"{k}_mean"] = sum(vals) / len(vals)
+    return summary
+
+
+def parse_nevents_from_log(log_bytes):
+    """Extract total event count from npsim or eicrecon log bytes."""
+    text = log_bytes.decode("utf-8", errors="replace")
+    # npsim: 'Finished run 0 after N events (N events in total)'
+    m = re.search(r"Finished run \d+ after \d+ events \((\d+) events in total\)", text)
+    if m:
+        return int(m.group(1))
+    # eicrecon: 'Opened PODIO file "..." with N events'
+    m = re.search(r'with (\d+) events \(format', text)
+    if m:
+        return int(m.group(1))
+    # eicrecon fallback: last 'Status: N events processed'
+    matches = re.findall(r"Status:\s+(\d+) events processed", text)
+    if matches:
+        return max(int(x) for x in matches)
+    return None
+
+
+def extract_prmon_from_bytes(tarball_bytes):
+    """Returns {step: summary_dict}, summary includes 'n_events' if found in log."""
+    results = {}
+    file_contents = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tf:
+            for member in tf.getmembers():
+                f = tf.extractfile(member)
+                if f:
+                    file_contents[member.name] = f.read()
+    except Exception as e:
+        print(f"    [ERROR] {e}")
+        return results
+
+    for step in STEPS:
+        prmon = next((c for n, c in file_contents.items() if f".{step}.prmon.txt" in n), None)
+        if prmon is None:
+            continue
+        summary = parse_prmon_txt(prmon)
+        if summary is None:
+            continue
+        log = next((c for n, c in file_contents.items() if f".{step}.log" in n), None)
+        if log:
+            n_ev = parse_nevents_from_log(log)
+            if n_ev is not None:
+                summary["n_events"] = n_ev
+        results[step] = summary
+
+    return results
+
+
+# ── Data collection ──────────────────────────────────────────────────────────
+
+def collect_data(label, log_dir, sample_size):
+    """Returns {step: [per-job summary dicts]}"""
+    print(f"\n### {label}")
+    print(f"    LOG dir: {log_dir}")
+    tarballs = collect_tarballs(log_dir)
+    n = min(sample_size, len(tarballs))
+    print(f"    Found {len(tarballs)} tarballs, sampling {n}")
+
+    if not tarballs:
+        print("    [WARN] No tarballs found.")
+        return {step: [] for step in STEPS}
+
+    sample = random.sample(tarballs, n)
+    step_summaries = {step: [] for step in STEPS}
+
+    for i, remote_path in enumerate(sample, 1):
+        basename = remote_path.split("/")[-1]
+        print(f"    [{i:2d}/{n}] {basename[:65]} ... ", end="", flush=True)
+        data = stream_tarball_bytes(remote_path)
+        if data is None:
+            print("FAILED")
+            continue
+        results = extract_prmon_from_bytes(data)
+        for step in STEPS:
+            if step in results:
+                step_summaries[step].append(results[step])
+        found = [s for s in STEPS if s in results]
+        print(f"ok ({', '.join(found)})")
+
+    return step_summaries
+
+
+# ── Plotting ─────────────────────────────────────────────────────────────────
+
+def make_histograms(datasets, timestamp):
+    """
+    datasets: list of (label, rucio_ds, {step: [summaries]})
+    One PNG per step, named with timestamp.
+    A single figure-level legend identifies each dataset by its full Rucio ID.
+    """
+    outfiles = []
+    for step in STEPS:
+        fig, axes = plt.subplots(2, 2, figsize=(13, 9))
+        fig.suptitle(f"PRMON distributions — {step}", fontsize=13, fontweight="bold")
+        axes = axes.flatten()
+
+        legend_handles = []
+
+        for ax, (field, label, unit, scale) in zip(axes, PLOT_METRICS):
+            key = f"{field}_max"
+
+            all_vals = []
+            for _, _ds, step_data in datasets:
+                summaries = step_data.get(step, [])
+                all_vals.extend(s[key] * scale for s in summaries if key in s)
+
+            if not all_vals:
+                ax.text(0.5, 0.5, "No data", transform=ax.transAxes,
+                        ha="center", va="center", color="gray", fontsize=12)
+                ax.set_title(label, fontsize=11)
+                continue
+
+            lo, hi = min(all_vals), max(all_vals)
+            if lo == hi:
+                lo -= 1; hi += 1
+            bins = np.linspace(lo, hi, 12)
+
+            for ci, (clabel, rucio_ds, step_data) in enumerate(datasets):
+                color = COLORS[ci % len(COLORS)]
+                summaries = step_data.get(step, [])
+                vals = [s[key] * scale for s in summaries if key in s]
+                if not vals:
+                    continue
+                ev_counts = [s["n_events"] for s in summaries if "n_events" in s]
+                ev_str = f", ~{int(np.median(ev_counts))} evts/job" if ev_counts else ""
+                ax.hist(vals, bins=bins, alpha=0.60, color=color,
+                        edgecolor="white", linewidth=0.5)
+                ax.axvline(np.mean(vals), color=color, linestyle="--",
+                           linewidth=1.8, alpha=0.95)
+                # Build legend handle once (first subplot is enough)
+                if len(legend_handles) < len(datasets):
+                    handle = mpatches.Patch(
+                        color=color,
+                        label=f"{clabel}  (n={len(vals)}{ev_str})\n{rucio_ds}"
+                    )
+                    legend_handles.append(handle)
+
+            ax.set_xlabel(f"{label} [{unit}]", fontsize=11)
+            ax.set_ylabel("Jobs", fontsize=11)
+            ax.set_title(label, fontsize=11)
+            ax.grid(True, alpha=0.3, linestyle="--")
+
+        # Single legend below all subplots
+        fig.legend(
+            handles=legend_handles,
+            loc="lower center",
+            ncol=len(datasets),
+            fontsize=9,
+            framealpha=0.9,
+            bbox_to_anchor=(0.5, 0.0),
+        )
+        plt.tight_layout(rect=[0, 0.13 * len(datasets), 1, 1])
+        outfile = f"prmon_compare_{step}_{timestamp}.png"
+        plt.savefig(outfile, dpi=150, bbox_inches="tight")
+        plt.close()
+        print(f"Saved: {outfile}")
+        outfiles.append(outfile)
+
+    return outfiles
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Compare PRMON logs for two Rucio RECO datasets."
+    )
+    parser.add_argument("--ds1", required=True,
+                        help="First Rucio dataset name (epic:/RECO/...)")
+    parser.add_argument("--ds2", required=True,
+                        help="Second Rucio dataset name (epic:/RECO/...)")
+    parser.add_argument("--label1", default=None,
+                        help="Legend label for ds1 (default: auto from path)")
+    parser.add_argument("--label2", default=None,
+                        help="Legend label for ds2 (default: auto from path)")
+    parser.add_argument("--sample", type=int, default=20,
+                        help="Number of jobs to sample per dataset (default: 20)")
+    parser.add_argument("--seed", type=int, default=42,
+                        help="Random seed (default: 42)")
+    return parser.parse_args()
+
+
+def auto_label(rucio_ds):
+    """Generate a short label from the Rucio path (version + energy)."""
+    parts = rucio_ds.replace("epic:/RECO/", "").split("/")
+    # parts[0] = version, parts[-1] = energy or minQ2
+    version = parts[0] if parts else "?"
+    energy  = next((p for p in reversed(parts) if "x" in p and p[0].isdigit()), "")
+    return f"{version} {energy}".strip()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    random.seed(args.seed)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    log1 = rucio_to_log_dir(args.ds1)
+    log2 = rucio_to_log_dir(args.ds2)
+
+    label1 = args.label1 or auto_label(args.ds1)
+    label2 = args.label2 or auto_label(args.ds2)
+
+    print(f"\nDataset 1: {label1}")
+    print(f"  Rucio : {args.ds1}")
+    print(f"  LOG   : {log1}")
+    print(f"\nDataset 2: {label2}")
+    print(f"  Rucio : {args.ds2}")
+    print(f"  LOG   : {log2}")
+
+    data1 = collect_data(label1, log1, args.sample)
+    data2 = collect_data(label2, log2, args.sample)
+
+    print("\nGenerating histograms...")
+    make_histograms([(label1, args.ds1, data1), (label2, args.ds2, data2)], timestamp)
+    print("Done.")

--- a/benchmarks/campaign_performance_metrics/plot_prmon_singles.py
+++ b/benchmarks/campaign_performance_metrics/plot_prmon_singles.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""
+Plot aggregate PRMON resource-usage histograms for all SINGLES datasets
+in a given EPIC campaign.
+
+Discovers datasets via:
+    rucio list-dids --filter type=DATASET 'epic:/RECO/*<campaign>*SINGLE*'
+
+For each discovered dataset a random sample of jobs is pulled from the
+corresponding XRootD LOG directory, parsed, and pooled into a single
+aggregate distribution.
+
+Usage:
+    python3 plot_prmon_singles.py --campaign 26.03.0 [--sample 5] [--seed 42]
+
+    # Dry-run: just list the datasets that would be queried
+    python3 plot_prmon_singles.py --campaign 26.03.0 --list-only
+"""
+
+import argparse
+import subprocess
+import random
+import tarfile
+import io
+import csv
+import re
+from collections import defaultdict
+from datetime import datetime
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+XROOT_BASE   = "root://dtn-eic.jlab.org"
+RUCIO_SCOPE  = "epic"
+RUCIO_PREFIX = "epic:/RECO"
+LOG_PREFIX   = "/work/eic3/EPIC/LOGS/LOG"
+
+STEPS = ["npsim", "eicrecon"]
+
+PLOT_METRICS = [
+    ("rss",   "Peak RSS Memory",  "MB", 1 / 1024),
+    ("vmem",  "Peak Vmem",        "MB", 1 / 1024),
+    ("wtime", "Wall Time",        "s",  1),
+    ("utime", "CPU Time (user)",  "s",  1),
+]
+
+
+# ── Rucio helpers ─────────────────────────────────────────────────────────────
+
+def rucio_list_singles(campaign):
+    """
+    Return a list of Rucio dataset DIDs matching the campaign SINGLES pattern.
+
+    Runs:
+        rucio list-dids --filter type=DATASET 'epic:/RECO/*<campaign>*SINGLE*'
+    """
+    pattern = f"{RUCIO_SCOPE}:/RECO/*{campaign}*SINGLE*"
+    print(f"Running: rucio list-dids --filter type=DATASET '{pattern}'")
+    result = subprocess.run(
+        ["rucio", "list-dids", "--filter", "type=DATASET", pattern],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"[ERROR] rucio list-dids failed:\n{result.stderr.strip()}")
+        return []
+
+    datasets = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        # rucio output lines look like:  | epic:/RECO/... | DATASET |
+        # or plain:  epic:/RECO/...
+        m = re.search(r"(epic:/RECO/\S+)", line)
+        if m:
+            did = m.group(1).rstrip("|").strip()
+            if "SINGLE" in did.upper() and campaign in did:
+                datasets.append(did)
+
+    return sorted(set(datasets))
+
+
+# ── Path conversion ───────────────────────────────────────────────────────────
+
+def rucio_to_log_dir(rucio_ds):
+    """Convert a Rucio dataset name to an XRootD LOG directory path."""
+    ds = rucio_ds.strip()
+    if not ds.startswith(RUCIO_PREFIX):
+        raise ValueError(
+            f"Dataset does not start with '{RUCIO_PREFIX}': {ds!r}"
+        )
+    return LOG_PREFIX + ds[len(RUCIO_PREFIX):]
+
+
+# ── XRootD helpers ────────────────────────────────────────────────────────────
+
+def xrdfs_ls(remote_dir):
+    result = subprocess.run(
+        ["xrdfs", XROOT_BASE, "ls", remote_dir],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return []
+    return [l.strip() for l in result.stdout.splitlines() if l.strip()]
+
+
+def collect_tarballs(log_dir):
+    """
+    Walk up to two levels under log_dir to find *.log.tar.gz files.
+    """
+    tarballs = []
+    top_entries = xrdfs_ls(log_dir)
+    for entry in top_entries:
+        if entry.endswith(".log.tar.gz"):
+            tarballs.append(entry)
+        else:
+            for sub in xrdfs_ls(entry):
+                if sub.endswith(".log.tar.gz"):
+                    tarballs.append(sub)
+    return tarballs
+
+
+def stream_tarball_bytes(remote_path):
+    url = f"{XROOT_BASE}/{remote_path}"
+    result = subprocess.run(["xrdcp", "--silent", url, "-"], capture_output=True)
+    return result.stdout if result.returncode == 0 else None
+
+
+# ── Parsing ───────────────────────────────────────────────────────────────────
+
+def parse_prmon_txt(content_bytes):
+    text = content_bytes.decode("utf-8", errors="replace")
+    reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+    rows = list(reader)
+    if not rows:
+        return None
+    columns = defaultdict(list)
+    for row in rows:
+        for k, v in row.items():
+            if k and k != "Time":
+                try:
+                    columns[k].append(float(v))
+                except (ValueError, TypeError):
+                    pass
+    summary = {"n_records": len(rows)}
+    for k, vals in columns.items():
+        if vals:
+            summary[f"{k}_max"]  = max(vals)
+            summary[f"{k}_mean"] = sum(vals) / len(vals)
+    return summary
+
+
+def parse_nevents_from_log(log_bytes):
+    """Extract total event count from npsim or eicrecon log bytes."""
+    text = log_bytes.decode("utf-8", errors="replace")
+    m = re.search(r"Finished run \d+ after \d+ events \((\d+) events in total\)", text)
+    if m:
+        return int(m.group(1))
+    m = re.search(r'with (\d+) events \(format', text)
+    if m:
+        return int(m.group(1))
+    matches = re.findall(r"Status:\s+(\d+) events processed", text)
+    if matches:
+        return max(int(x) for x in matches)
+    return None
+
+
+def extract_prmon_from_bytes(tarball_bytes):
+    """Returns {step: summary_dict}."""
+    results = {}
+    file_contents = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tf:
+            for member in tf.getmembers():
+                f = tf.extractfile(member)
+                if f:
+                    file_contents[member.name] = f.read()
+    except Exception as e:
+        print(f"    [ERROR] {e}")
+        return results
+
+    for step in STEPS:
+        prmon = next((c for n, c in file_contents.items() if f".{step}.prmon.txt" in n), None)
+        if prmon is None:
+            continue
+        summary = parse_prmon_txt(prmon)
+        if summary is None:
+            continue
+        log = next((c for n, c in file_contents.items() if f".{step}.log" in n), None)
+        if log:
+            n_ev = parse_nevents_from_log(log)
+            if n_ev is not None:
+                summary["n_events"] = n_ev
+        results[step] = summary
+
+    return results
+
+
+# ── Data collection ───────────────────────────────────────────────────────────
+
+def collect_data_for_dataset(rucio_ds, sample_size):
+    """
+    Returns {step: [per-job summary dicts]} for a single Rucio dataset.
+    """
+    log_dir = rucio_to_log_dir(rucio_ds)
+    tarballs = collect_tarballs(log_dir)
+    n = min(sample_size, len(tarballs))
+
+    if not tarballs:
+        print(f"    [WARN] No tarballs found in {log_dir}")
+        return {step: [] for step in STEPS}
+
+    print(f"    Found {len(tarballs)} tarballs, sampling {n}")
+    sample = random.sample(tarballs, n)
+    step_summaries = {step: [] for step in STEPS}
+
+    for i, remote_path in enumerate(sample, 1):
+        basename = remote_path.split("/")[-1]
+        print(f"    [{i:2d}/{n}] {basename[:65]} ... ", end="", flush=True)
+        data = stream_tarball_bytes(remote_path)
+        if data is None:
+            print("FAILED")
+            continue
+        results = extract_prmon_from_bytes(data)
+        for step in STEPS:
+            if step in results:
+                step_summaries[step].append(results[step])
+        found = [s for s in STEPS if s in results]
+        print(f"ok ({', '.join(found)})")
+
+    return step_summaries
+
+
+def collect_all_singles(datasets, sample_size):
+    """
+    Iterate over all SINGLES datasets, collect samples, and return:
+        aggregate: {step: [all per-job summaries]}
+        per_ds:    {rucio_ds: {step: [per-job summaries]}}
+    """
+    aggregate  = {step: [] for step in STEPS}
+    per_ds     = {}
+
+    for idx, ds in enumerate(datasets, 1):
+        short = ds.replace(RUCIO_PREFIX + "/", "")
+        print(f"\n[{idx}/{len(datasets)}] {short}")
+        ds_data = collect_data_for_dataset(ds, sample_size)
+        per_ds[ds] = ds_data
+        for step in STEPS:
+            aggregate[step].extend(ds_data[step])
+
+    return aggregate, per_ds
+
+
+# ── Plotting ──────────────────────────────────────────────────────────────────
+
+def make_aggregate_histograms(aggregate, campaign, n_datasets, timestamp):
+    """
+    aggregate : {step: [per-job summary dicts]}  (all datasets pooled)
+    Produces one PNG per step with 2x2 metric histograms.
+    """
+    outfiles = []
+    for step in STEPS:
+        summaries = aggregate.get(step, [])
+        n_jobs = len(summaries)
+
+        fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+        fig.suptitle(
+            f"PRMON aggregate — {step}  |  campaign: {campaign}\n"
+            f"({n_jobs} jobs sampled across {n_datasets} SINGLES datasets)",
+            fontsize=12, fontweight="bold"
+        )
+        axes = axes.flatten()
+
+        for ax, (field, label, unit, scale) in zip(axes, PLOT_METRICS):
+            key = f"{field}_max"
+            vals = [s[key] * scale for s in summaries if key in s]
+
+            if not vals:
+                ax.text(0.5, 0.5, "No data", transform=ax.transAxes,
+                        ha="center", va="center", color="gray", fontsize=12)
+                ax.set_title(label, fontsize=11)
+                continue
+
+            mu  = np.mean(vals)
+            med = np.median(vals)
+            p95 = np.percentile(vals, 95)
+
+            bins = np.linspace(min(vals), max(vals), 30)
+            ax.hist(vals, bins=bins, color="#4C72B0", alpha=0.75,
+                    edgecolor="white", linewidth=0.5)
+            ax.axvline(mu,  color="#DD8452", linestyle="--", linewidth=1.8,
+                       label=f"mean {mu:.1f}")
+            ax.axvline(med, color="#55A868", linestyle=":",  linewidth=1.8,
+                       label=f"median {med:.1f}")
+            ax.axvline(p95, color="#C44E52", linestyle="-.", linewidth=1.5,
+                       label=f"p95 {p95:.1f}")
+
+            ax.set_xlabel(f"{label} [{unit}]", fontsize=10)
+            ax.set_ylabel("Jobs", fontsize=10)
+            ax.set_title(label, fontsize=11)
+            ax.legend(fontsize=8, framealpha=0.85)
+            ax.grid(True, alpha=0.3, linestyle="--")
+
+        plt.tight_layout()
+        outfile = f"prmon_singles_{step}_{campaign}_{timestamp}.png"
+        plt.savefig(outfile, dpi=150, bbox_inches="tight")
+        plt.close()
+        print(f"Saved: {outfile}")
+        outfiles.append(outfile)
+
+    return outfiles
+
+
+def make_per_dataset_histograms(per_ds, campaign, timestamp):
+    """
+    One figure per step showing overlaid per-dataset distributions so outlier
+    datasets are easy to spot. Each dataset gets its own color; legend shows
+    the short dataset name and job count.
+    """
+    # Build a stable color cycle
+    cmap = plt.get_cmap("tab20")
+    ds_list = list(per_ds.keys())
+    colors  = [cmap(i / max(len(ds_list), 1)) for i in range(len(ds_list))]
+
+    outfiles = []
+    for step in STEPS:
+        fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+        fig.suptitle(
+            f"PRMON per-dataset overlay — {step}  |  campaign: {campaign}",
+            fontsize=12, fontweight="bold"
+        )
+        axes = axes.flatten()
+        legend_handles = []
+
+        for ax, (field, label, unit, scale) in zip(axes, PLOT_METRICS):
+            key = f"{field}_max"
+
+            # Compute global range for shared bins
+            all_vals = []
+            for ds in ds_list:
+                summaries = per_ds[ds].get(step, [])
+                all_vals.extend(s[key] * scale for s in summaries if key in s)
+
+            if not all_vals:
+                ax.text(0.5, 0.5, "No data", transform=ax.transAxes,
+                        ha="center", va="center", color="gray", fontsize=12)
+                ax.set_title(label, fontsize=11)
+                continue
+
+            lo, hi = min(all_vals), max(all_vals)
+            if lo == hi:
+                lo -= 1; hi += 1
+            bins = np.linspace(lo, hi, 20)
+
+            for ci, ds in enumerate(ds_list):
+                color     = colors[ci]
+                summaries = per_ds[ds].get(step, [])
+                vals      = [s[key] * scale for s in summaries if key in s]
+                if not vals:
+                    continue
+                short = ds.replace(RUCIO_PREFIX + "/", "").split("/")[-1]
+                ax.hist(vals, bins=bins, alpha=0.45, color=color,
+                        edgecolor="white", linewidth=0.4)
+                ax.axvline(np.mean(vals), color=color, linestyle="--",
+                           linewidth=1.4, alpha=0.9)
+                # Collect handles once (first metric subplot)
+                if ax is axes[0]:
+                    handle = mpatches.Patch(
+                        color=color,
+                        label=f"{short}  (n={len(vals)})"
+                    )
+                    legend_handles.append(handle)
+
+            ax.set_xlabel(f"{label} [{unit}]", fontsize=10)
+            ax.set_ylabel("Jobs", fontsize=10)
+            ax.set_title(label, fontsize=11)
+            ax.grid(True, alpha=0.3, linestyle="--")
+
+        # Legend outside the subplots
+        fig.legend(
+            handles=legend_handles,
+            loc="lower center",
+            ncol=min(4, len(ds_list)),
+            fontsize=7,
+            framealpha=0.9,
+            bbox_to_anchor=(0.5, 0.0),
+        )
+        n_rows = max(1, len(ds_list) // 4)
+        plt.tight_layout(rect=[0, 0.04 * n_rows + 0.04, 1, 1])
+        outfile = f"prmon_singles_perds_{step}_{campaign}_{timestamp}.png"
+        plt.savefig(outfile, dpi=150, bbox_inches="tight")
+        plt.close()
+        print(f"Saved: {outfile}")
+        outfiles.append(outfile)
+
+    return outfiles
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Aggregate PRMON plots for all SINGLES datasets in a campaign."
+    )
+    parser.add_argument(
+        "--campaign", required=True,
+        help="Campaign string to match (e.g. '26.03.0').  "
+             "Queries: rucio list-dids 'epic:/RECO/*<campaign>*SINGLE*'"
+    )
+    parser.add_argument(
+        "--sample", type=int, default=5,
+        help="Number of jobs to sample per dataset (default: 5)"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Random seed (default: 42)"
+    )
+    parser.add_argument(
+        "--list-only", action="store_true",
+        help="Just print the matching datasets and exit; do not fetch any data."
+    )
+    parser.add_argument(
+        "--no-per-dataset", action="store_true",
+        help="Skip the per-dataset overlay plot (only produce aggregate)."
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    random.seed(args.seed)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    # ── 1. Discover datasets ──────────────────────────────────────────────────
+    print(f"\n=== Discovering SINGLES datasets for campaign: {args.campaign} ===")
+    datasets = rucio_list_singles(args.campaign)
+
+    if not datasets:
+        print("[ERROR] No matching datasets found. Check campaign string and Rucio credentials.")
+        raise SystemExit(1)
+
+    print(f"\nFound {len(datasets)} dataset(s):")
+    for ds in datasets:
+        print(f"  {ds}")
+
+    if args.list_only:
+        raise SystemExit(0)
+
+    # ── 2. Collect data ───────────────────────────────────────────────────────
+    print(f"\n=== Collecting data ({args.sample} jobs/dataset) ===")
+    aggregate, per_ds = collect_all_singles(datasets, args.sample)
+
+    total_jobs = {step: len(aggregate[step]) for step in STEPS}
+    print(f"\nTotal jobs collected: { {s: total_jobs[s] for s in STEPS} }")
+
+    # ── 3. Plot ───────────────────────────────────────────────────────────────
+    print("\n=== Generating plots ===")
+    make_aggregate_histograms(aggregate, args.campaign, len(datasets), timestamp)
+
+    if not args.no_per_dataset and len(datasets) > 1:
+        make_per_dataset_histograms(per_ds, args.campaign, timestamp)
+
+    print("\nDone.")

--- a/benchmarks/campaign_performance_metrics/plot_singles_aggregate.py
+++ b/benchmarks/campaign_performance_metrics/plot_singles_aggregate.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Aggregate per-dataset JSON files and produce PRMON histogram plots.
+
+Reads all JSON files produced by collect_dataset.py, merges them, and
+generates:
+  1. Aggregate histograms (all datasets pooled)
+  2. Per-dataset overlay histograms (one color per dataset)
+
+Usage:
+    python3 plot_singles_aggregate.py \
+        --campaign 26.03.0 \
+        --output-dir results/campaign_performance_metrics \
+        collected/dataset_0.json collected/dataset_1.json ...
+"""
+
+import argparse
+import json
+import sys
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+
+STEPS = ["npsim", "eicrecon"]
+
+PLOT_METRICS = [
+    ("rss",   "Peak RSS Memory",  "MB", 1 / 1024),
+    ("vmem",  "Peak Vmem",        "MB", 1 / 1024),
+    ("wtime", "Wall Time",        "s",  1),
+    ("utime", "CPU Time (user)",  "s",  1),
+]
+
+RUCIO_PREFIX = "epic:/RECO"
+
+
+# ── Data loading ─────────────────────────────────────────────────────────────
+
+def load_and_merge(json_files):
+    aggregate = {step: [] for step in STEPS}
+    per_ds = {}
+
+    for path in json_files:
+        with open(path) as f:
+            blob = json.load(f)
+        ds_name = blob["dataset"]
+        data = blob["data"]
+        per_ds[ds_name] = data
+        for step in STEPS:
+            aggregate[step].extend(data.get(step, []))
+
+    return aggregate, per_ds
+
+
+# ── Plotting ─────────────────────────────────────────────────────────────────
+
+def make_aggregate_histograms(aggregate, campaign, n_datasets, outdir):
+    outfiles = []
+    for step in STEPS:
+        summaries = aggregate.get(step, [])
+        n_jobs = len(summaries)
+
+        fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+        fig.suptitle(
+            f"PRMON aggregate \u2014 {step}  |  campaign: {campaign}\n"
+            f"({n_jobs} jobs sampled across {n_datasets} SINGLES datasets)",
+            fontsize=12, fontweight="bold",
+        )
+        axes = axes.flatten()
+
+        for ax, (field, label, unit, scale) in zip(axes, PLOT_METRICS):
+            key = f"{field}_max"
+            vals = [s[key] * scale for s in summaries if key in s]
+
+            if not vals:
+                ax.text(0.5, 0.5, "No data", transform=ax.transAxes,
+                        ha="center", va="center", color="gray", fontsize=12)
+                ax.set_title(label, fontsize=11)
+                continue
+
+            mu = np.mean(vals)
+            med = np.median(vals)
+            p95 = np.percentile(vals, 95)
+
+            bins = np.linspace(min(vals), max(vals), 30)
+            ax.hist(vals, bins=bins, color="#4C72B0", alpha=0.75,
+                    edgecolor="white", linewidth=0.5)
+            ax.axvline(mu, color="#DD8452", linestyle="--", linewidth=1.8,
+                       label=f"mean {mu:.1f}")
+            ax.axvline(med, color="#55A868", linestyle=":", linewidth=1.8,
+                       label=f"median {med:.1f}")
+            ax.axvline(p95, color="#C44E52", linestyle="-.", linewidth=1.5,
+                       label=f"p95 {p95:.1f}")
+
+            ax.set_xlabel(f"{label} [{unit}]", fontsize=10)
+            ax.set_ylabel("Jobs", fontsize=10)
+            ax.set_title(label, fontsize=11)
+            ax.legend(fontsize=8, framealpha=0.85)
+            ax.grid(True, alpha=0.3, linestyle="--")
+
+        plt.tight_layout()
+        outfile = f"{outdir}/prmon_singles_{step}_{campaign}.png"
+        plt.savefig(outfile, dpi=150, bbox_inches="tight")
+        plt.close()
+        print(f"Saved: {outfile}")
+        outfiles.append(outfile)
+
+    return outfiles
+
+
+def make_per_dataset_histograms(per_ds, campaign, outdir):
+    import os
+
+    ds_subdir = os.path.join(outdir, "per_dataset")
+    os.makedirs(ds_subdir, exist_ok=True)
+
+    step_colors = {"npsim": "#4C72B0", "eicrecon": "#DD8452"}
+
+    outfiles = []
+    for ds_name, data in per_ds.items():
+        # Build a safe filename from the dataset path
+        safe = ds_name.replace(RUCIO_PREFIX + "/", "").replace("/", "_")
+        outfile = os.path.join(ds_subdir, f"{safe}.png")
+
+        # 2 rows (steps) x 4 cols (metrics)
+        fig, axes = plt.subplots(
+            len(STEPS), len(PLOT_METRICS),
+            figsize=(16, 5 * len(STEPS)),
+            squeeze=False,
+        )
+        short_name = ds_name.replace(RUCIO_PREFIX + "/", "")
+        fig.suptitle(
+            f"PRMON \u2014 {short_name}\ncampaign: {campaign}",
+            fontsize=11, fontweight="bold",
+        )
+
+        for row, step in enumerate(STEPS):
+            summaries = data.get(step, [])
+            for col, (field, label, unit, scale) in enumerate(PLOT_METRICS):
+                ax = axes[row][col]
+                key = f"{field}_max"
+                vals = [s[key] * scale for s in summaries if key in s]
+
+                ax.set_title(f"{step} \u2014 {label}", fontsize=9)
+                ax.set_xlabel(f"{label} [{unit}]", fontsize=8)
+                ax.set_ylabel("Jobs", fontsize=8)
+                ax.grid(True, alpha=0.3, linestyle="--")
+
+                if not vals:
+                    ax.text(0.5, 0.5, "No data", transform=ax.transAxes,
+                            ha="center", va="center", color="gray", fontsize=10)
+                    continue
+
+                mu  = np.mean(vals)
+                med = np.median(vals)
+                p95 = np.percentile(vals, 95)
+
+                lo, hi = min(vals), max(vals)
+                if lo == hi:
+                    lo -= 0.5
+                    hi += 0.5
+                bins = np.linspace(lo, hi, max(5, min(20, len(vals))))
+
+                color = step_colors.get(step, "#4C72B0")
+                ax.hist(vals, bins=bins, color=color, alpha=0.75,
+                        edgecolor="white", linewidth=0.5)
+                ax.axvline(mu,  color="#55A868", linestyle="--", linewidth=1.6,
+                           label=f"mean {mu:.1f}")
+                ax.axvline(med, color="#C44E52", linestyle=":",  linewidth=1.6,
+                           label=f"median {med:.1f}")
+                ax.axvline(p95, color="#8172B2", linestyle="-.", linewidth=1.4,
+                           label=f"p95 {p95:.1f}")
+                ax.legend(fontsize=7, framealpha=0.85)
+
+        plt.tight_layout()
+        plt.savefig(outfile, dpi=150, bbox_inches="tight")
+        plt.close()
+        print(f"Saved: {outfile}")
+        outfiles.append(outfile)
+
+    return outfiles
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate per-dataset JSON files and produce plots.",
+    )
+    parser.add_argument("--campaign", required=True,
+                        help="Campaign string (used in plot titles)")
+    parser.add_argument("--output-dir", required=True,
+                        help="Directory for output plots")
+    parser.add_argument("--no-per-dataset", action="store_true",
+                        help="Skip per-dataset overlay plots")
+    parser.add_argument("json_files", nargs="+",
+                        help="Per-dataset JSON files from collect_dataset.py")
+    args = parser.parse_args()
+
+    print(f"Loading {len(args.json_files)} dataset file(s)...")
+    aggregate, per_ds = load_and_merge(args.json_files)
+
+    for step in STEPS:
+        print(f"  {step}: {len(aggregate[step])} total jobs")
+
+    print("\nGenerating aggregate plots...")
+    make_aggregate_histograms(
+        aggregate, args.campaign, len(per_ds), args.output_dir,
+    )
+
+    if not args.no_per_dataset and len(per_ds) > 1:
+        print("Generating per-dataset overlay plots...")
+        make_per_dataset_histograms(per_ds, args.campaign, args.output_dir)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Adds a new benchmark that discovers SINGLES datasets for a given campaign via Rucio, samples PRMON log tarballs per dataset, and produces per-dataset and aggregate histogram plots for RSS, Vmem, wall time, and CPU time across npsim and eicrecon steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### What is the urgency of this PR?
- [ ] High
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
