### PR TITLE
feat: add Rucio storage plugin integration for benchmark outputs (barrel_ecal PoC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ The `config.yml` will require an include from the `./.gitlab-ci.yml`.
 
  - Create a script that returns exit status 0 for success.
  - Any non-zero value will be considered failure.
+
+## Uploading outputs to Rucio
+
+Benchmark outputs are uploaded to Rucio as part of each producing rule when
+`config.rucio.host` is set (see `snakemake.yml`).  Invoke with:
+
+```bash
+snakemake --profile profiles/rucio --cores 4 <target>
+```

--- a/Snakefile
+++ b/Snakefile
@@ -2,7 +2,35 @@ configfile: "snakemake.yml"
 
 import functools
 import os
+import re
 from snakemake.logging import logger
+
+
+_rucio_upload_enabled = bool(config.get("rucio", {}).get("host"))
+if not _rucio_upload_enabled:
+    logger.warning(
+        "Rucio host not configured (config.rucio.host); "
+        "benchmark outputs will not be uploaded to Rucio."
+    )
+
+_rucio_scope     = config.get("rucio", {}).get("scope", "epic")
+_rucio_job_id    = config.get("job_id", os.environ.get("CI_PIPELINE_ID", "local"))
+_RUCIO_DID_PREFIX = f"rucio://{_rucio_scope}/VALIDATION/benchmarks/detector/{_rucio_job_id}"
+
+
+def _rucio_output(path):
+    """Return a Rucio storage() output, or a local temp() placeholder when
+    Rucio is not configured (e.g. in local test runs).
+
+    When storage() is used, {output.rucio} in shell commands resolves to a
+    *local* staging path managed by Snakemake — a plain cp is all that is
+    needed.  Snakemake uploads the staged file to the remote Rucio server
+    after the job completes successfully.
+    """
+    if _rucio_upload_enabled:
+        return storage(path)
+    local = re.sub(r"^rucio://[^/]*/", ".rucio_staging/", path)
+    return temp(local)
 
 
 rule compile_analysis:
@@ -74,15 +102,24 @@ include: "benchmarks/nhcal_basic_distribution/Snakefile"
 
 use_s3 = config["remote_provider"].lower() == "s3"
 use_xrootd = config["remote_provider"].lower() == "xrootd"
+use_rucio = config["remote_provider"].lower() == "rucio"
+
+_xrootd_cfg = config.get("xrootd", {})
+_xrootd_server = _xrootd_cfg.get("server", "root://dtn-eic.jlab.org")
+_xrootd_base = _xrootd_cfg.get("base_path", "/volatile/eic").strip("/")
+# Full base URL used by get_remote_path() and the fetch_epic rule.
+_xrootd_base_url = f"{_xrootd_server}//{_xrootd_base}"
 
 
 def get_remote_path(path):
     if use_s3:
         return f"s3https://eics3.sdcc.bnl.gov:9000/eictest/{path}"
-    elif use_xrootd:
-        return f"root://dtn-eic.jlab.org//volatile/eic/{path}"
+    elif use_xrootd or use_rucio:
+        # EIC-XRD is an XRootD-backed RSE; the configured XRootD server is
+        # used for both xrootd and rucio remote_provider modes.
+        return f"{_xrootd_base_url}/{path}"
     else:
-        raise runtime_exception('Unexpected value for config["remote_provider"]: {config["remote_provider"]}')
+        raise RuntimeError(f'Unexpected value for config["remote_provider"]: {config["remote_provider"]}')
 
 
 rule fetch_epic:
@@ -90,12 +127,13 @@ rule fetch_epic:
         filepath="EPIC/{PATH}"
     params:
         # wildcards are not included in hash for caching, we need to add them as params
-        PATH=lambda wildcards: wildcards.PATH
+        PATH=lambda wildcards: wildcards.PATH,
+        xrd_base=_xrootd_base_url,
     cache: True
     retries: 3
     shell: """
-xrdcp --debug 2 root://dtn-eic.jlab.org//volatile/eic/{output.filepath} {output.filepath}
-""" if use_xrootd else """
+xrdcp --debug 2 {params.xrd_base}/{output.filepath} {output.filepath}
+""" if use_xrootd or use_rucio else """
 mc cp S3/eictest/{output.filepath} {output.filepath}
 """ if use_s3 else f"""
 echo 'Unexpected value for config["remote_provider"]: {config["remote_provider"]}'

--- a/benchmarks/barrel_ecal/Snakefile
+++ b/benchmarks/barrel_ecal/Snakefile
@@ -1,5 +1,7 @@
 DETECTOR_PATH = os.environ["DETECTOR_PATH"]
 
+_RUCIO_BASE = f"{_RUCIO_DID_PREFIX}/barrel_ecal"
+
 
 rule emcal_barrel_particles_gen:
     input:
@@ -24,12 +26,13 @@ rule emcal_barrel_particles:
         DD4HEP_HASH=get_spack_package_hash("dd4hep"),
         NPSIM_HASH=get_spack_package_hash("npsim"),
     output:
-        "{DETECTOR_CONFIG}/sim_output/sim_emcal_barrel_{PARTICLE}_energies{E_MIN}_{E_MAX}.edm4hep.root"
+        local="{DETECTOR_CONFIG}/sim_output/sim_emcal_barrel_{PARTICLE}_energies{E_MIN}_{E_MAX}.edm4hep.root",
+        rucio=_rucio_output(f"{_RUCIO_BASE}/sim_output/sim_emcal_barrel_{{PARTICLE}}_energies{{E_MIN}}_{{E_MAX}}.edm4hep.root"),
     cache: True
     shell:
         """
 set -m # monitor mode to prevent lingering processes
-exec npsim \
+npsim \
    --runType batch \
    -v WARNING \
    --part.minimalKineticEnergy 0.5*GeV  \
@@ -37,7 +40,8 @@ exec npsim \
    --numberOfEvents {params.JUGGLER_N_EVENTS} \
    --compactFile """ + DETECTOR_PATH + """/{wildcards.DETECTOR_CONFIG}.xml \
    --inputFiles {input.hepmc} \
-   --outputFile {output}
+   --outputFile {output.local}
+exec cp {output.local} {output.rucio}
 """
 
 
@@ -77,7 +81,8 @@ rule emcal_barrel_particles_analysis:
     wildcard_constraints:
         PARTICLE="(electron|photon|piplus|piminus)", # avoid clash with "pions"
     output:
-        "{DETECTOR_CONFIG}/results/emcal_barrel_{PARTICLE}_calibration.json",
+        calibration_json="{DETECTOR_CONFIG}/results/emcal_barrel_{PARTICLE}_calibration.json",
+        rucio=_rucio_output(f"{_RUCIO_BASE}/results/emcal_barrel_{{PARTICLE}}_calibration.json"),
         "{DETECTOR_CONFIG}/results/emcal_barrel_{PARTICLE}_Ethr.png",
         "{DETECTOR_CONFIG}/results/emcal_barrel_{PARTICLE}_Ethr.pdf",
         "{DETECTOR_CONFIG}/results/emcal_barrel_{PARTICLE}_nhits.png",
@@ -94,6 +99,8 @@ rule emcal_barrel_particles_analysis:
         """
 cd {wildcards.DETECTOR_CONFIG}
 root -l -b -q '{input.script}+("{wildcards.PARTICLE}", true)'
+cd - > /dev/null
+exec cp {output.calibration_json} {output.rucio}
 """
 
 
@@ -125,11 +132,14 @@ rule emcal_barrel_pi0_analysis:
             var_name=["Ethr", "nhits", "Esim", "dE_rel"],
             extension=["pdf", "png"],
         ),
-        "{DETECTOR_CONFIG}/results/Barrel_emcal_pi0.json"
+        pi0_json="{DETECTOR_CONFIG}/results/Barrel_emcal_pi0.json",
+        rucio=_rucio_output(f"{_RUCIO_BASE}/results/Barrel_emcal_pi0.json"),
     shell:
         """
 cd {wildcards.DETECTOR_CONFIG}
 root -l -b -q '{input.script}+("../{input.sim}")'
+cd - > /dev/null
+exec cp {output.pi0_json} {output.rucio}
 """
 
 
@@ -173,7 +183,8 @@ rule emcal_barrel_pion_rejection_analysis:
         piminus="{DETECTOR_CONFIG}/sim_output/sim_emcal_barrel_piminus_energies1.0_18.0.edm4hep.root",
     output:
         "{DETECTOR_CONFIG}/results/emcal_barrel_pion_rej_RatioRej.png",
-        "{DETECTOR_CONFIG}/results/Barrel_emcal_pion_rej.json",
+        pion_rej_json="{DETECTOR_CONFIG}/results/Barrel_emcal_pion_rej.json",
+        rucio=_rucio_output(f"{_RUCIO_BASE}/results/Barrel_emcal_pion_rej.json"),
         expand(
             "{{DETECTOR_CONFIG}}/results/emcal_barrel_pion_rej_uncut_comb_{var_save}.png",
             var_save=["Esim", "EsimTot", "EDep6", "EDep6OverP", "pT", "eta", "EsimScFi", "EsimScFiOverP"],
@@ -197,4 +208,6 @@ rule emcal_barrel_pion_rejection_analysis:
         """
 cd {wildcards.DETECTOR_CONFIG}
 root -l -b -q '{input.script}+g("../{input.electron}", "../{input.piminus}")'
+cd - > /dev/null
+exec cp {output.pion_rej_json} {output.rucio}
 """

--- a/profiles/rucio/config.yaml
+++ b/profiles/rucio/config.yaml
@@ -1,0 +1,23 @@
+# Snakemake profile for uploading benchmark outputs to Rucio.
+#
+# Uses snakemake-storage-plugin-rucio.  Rucio connection details (host, auth)
+# are read from the standard Rucio client configuration (~/.rucio/rucio.cfg or
+# environment variables such as RUCIO_HOST, RUCIO_ACCOUNT, RUCIO_AUTH_TYPE).
+#
+# Usage:
+#   snakemake --profile profiles/rucio --cores 1 \
+#     epic_craterlake/publish/barrel_ecal_all.done
+#
+# Override job_id (defaults to CI_PIPELINE_ID env var, then "local"):
+#   snakemake --profile profiles/rucio --config job_id=12345 --cores 1 \
+#     epic_craterlake/publish/barrel_ecal_all.done
+#
+# Required environment variables (set before invoking snakemake):
+#   RUCIO_ACCOUNT   - your Rucio account name
+#
+# Authentication (choose one):
+#   X509_USER_PROXY - path to a valid VOMS proxy  (auth_type=x509_proxy), or
+#   RUCIO_AUTH_TYPE=userpass with RUCIO_USERNAME / RUCIO_PASSWORD
+
+# Upload to the JLab RSE by default; override with --storage-rucio-upload-rse BNL-XRD
+storage-rucio-upload-rse: EIC-XRD

--- a/snakemake.yml
+++ b/snakemake.yml
@@ -1,1 +1,23 @@
 remote_provider: XRootD
+
+# XRootD server used for reading input files (remote_provider: xrootd or rucio).
+# Uncomment the BNL block to read from BNL instead of JLab.
+xrootd:
+  server: root://dtn-eic.jlab.org
+  base_path: /volatile/eic
+# BNL alternative:
+# xrootd:
+#   server: root://epicxrd1.sdcc.bnl.gov:1094  # authenticated; use port 1095 for no-auth
+#   base_path: /path/at/bnl                     # TODO: confirm the BNL base path
+
+# Rucio server used for uploading benchmark outputs.
+# Uncomment the BNL block to upload to BNL instead of JLab.
+rucio:
+  host: https://rucio-server.jlab.org:443
+  rse: EIC-XRD
+  scope: epic
+# BNL alternative:
+# rucio:
+#   host: https://nprucio01.sdcc.bnl.gov:443
+#   rse: BNL-XRD
+#   scope: epic


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
- Add `rucio:` and `xrootd:` config blocks to `snakemake.yml` with JLab defaults and commented BNL alternatives
- Root `Snakefile`: add `_rucio_upload_enabled` flag, `_rucio_output()` helper, and shared `_RUCIO_DID_PREFIX = rucio://{scope}/VALIDATION/benchmarks/detector/{job_id}`
- Root `Snakefile`: add configurable `_xrootd_base_url`; fix `get_remote_path()` to support Rucio reads
- barrel_ecal `Snakefile`: integrate Rucio storage outputs directly into the four producing rules (sim, particles_analysis, pi0_analysis, pion_rejection_analysis)
- Add `profiles/rucio/config.yaml` with `storage-rucio-upload-rse` setting
- `README`: document Rucio upload configuration

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Developed together with copilot. Wish I didn't have to steer it as mush as I did...