### PR TITLE
chore: remove unused common_bench header includes

### DIFF
--- a/benchmarks/b0_tracker/analysis/b0_tracker_hits.cxx
+++ b/benchmarks/b0_tracker/analysis/b0_tracker_hits.cxx
@@ -18,10 +18,6 @@ R__LOAD_LIBRARY(libfmt.so)
 
 #include "edm4hep/SimTrackerHitCollection.h"
 
-#include "common_bench/particles.h"
-#include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
-#include "common_bench/util.h"
 
 void b0_tracker_hits(const char* fname = "./sim_output/sim_forward_protons.edm4hep.root"){
 

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pi0_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pi0_analysis.cxx
@@ -10,8 +10,6 @@
 #include "edm4hep/SimCalorimeterHitCollection.h"
 
 #include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
-#include "common_bench/util.h"
 
 R__LOAD_LIBRARY(libfmt.so)
 #include "fmt/core.h"

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx
@@ -12,8 +12,6 @@
 #include "edm4hep/SimCalorimeterHitCollection.h"
 
 #include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
-#include "common_bench/util.h"
 
 #include <boost/range/combine.hpp>
 

--- a/benchmarks/barrel_ecal/scripts/emcal_barrel_pions_analysis.cxx
+++ b/benchmarks/barrel_ecal/scripts/emcal_barrel_pions_analysis.cxx
@@ -9,9 +9,6 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 
-#include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
-#include "common_bench/util.h"
 
 #include "TCanvas.h"
 #include "TStyle.h"


### PR DESCRIPTION
## Summary

A systematic audit of all analysis scripts in this repo found several `common_bench` headers that are included but whose symbols are never referenced.

## Changes

| File | Removed includes |
|------|-----------------|
| `benchmarks/b0_tracker/analysis/b0_tracker_hits.cxx` | `particles.h`, `benchmark.h`, `mt.h`, `util.h` (all four — uses `ROOT::EnableImplicitMT()` directly, no `common_bench::` symbols) |
| `benchmarks/barrel_ecal/scripts/emcal_barrel_pions_analysis.cxx` | `benchmark.h`, `mt.h`, `util.h` (no `common_bench::` symbols used) |
| `benchmarks/barrel_ecal/scripts/emcal_barrel_pi0_analysis.cxx` | `mt.h`, `util.h` (`benchmark.h` kept for `common_bench::Test`/`write_test`) |
| `benchmarks/barrel_ecal/scripts/emcal_barrel_pion_rejection_analysis.cxx` | `mt.h`, `util.h` (`benchmark.h` kept for `common_bench::Test`/`write_test`) |

## Notes

- `kNumThreads` from `mt.h` is only needed when passing a thread count to `EnableImplicitMT(n)`. Files calling `ROOT::EnableImplicitMT()` with no argument do not need `mt.h`.
- `util.h` provides physics helpers (`get_pdg_mass`, `momenta_from_simulation`, etc.) — none used in these barrel_ecal scripts.