### PR TITLE
ci: propagate source repository/SHA to GitLab trigger for cross-repo status reporting

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -21,10 +21,6 @@ on:
         description: 'PR number in source repository'
         required: false
         default: ''
-      SOURCE_REF:
-        description: 'Source branch ref'
-        required: false
-        default: ''
       SOURCE_TITLE:
         description: 'Pipeline name / PR title'
         required: false

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -66,7 +66,7 @@ jobs:
           PIPELINE_NAME=${{ inputs.SOURCE_REPOSITORY || github.repository }}: ${{ inputs.SOURCE_TITLE || github.event.pull_request.title || github.ref_name }}
           COMMON_BENCH_VERSION=${{ inputs.COMMON_BENCH_VERSION }}
     - name: Set pending EICweb status
-      if: ${{ github.event_name != 'delete' && inputs.SOURCE_SHA == '' }}
+      if: ${{ github.event_name != 'delete' && !inputs.SOURCE_SHA }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DETECTOR_CONFIG: epic_craterlake

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -9,6 +9,26 @@ on:
         description: 'common_bench branch/tag to use'
         required: false
         default: ''
+      SOURCE_REPOSITORY:
+        description: 'Repository to report status to (owner/repo)'
+        required: false
+        default: ''
+      SOURCE_SHA:
+        description: 'Commit SHA to report status to'
+        required: false
+        default: ''
+      SOURCE_PR:
+        description: 'PR number in source repository'
+        required: false
+        default: ''
+      SOURCE_REF:
+        description: 'Source branch ref'
+        required: false
+        default: ''
+      SOURCE_TITLE:
+        description: 'Pipeline name / PR title'
+        required: false
+        default: ''
 
 concurrency:
   group: mirror-${{ github.event_name }}
@@ -44,13 +64,13 @@ jobs:
         token: ${{ secrets.EICWEB_DETECTOR_BENCHMARKS_TRIGGER }}
         ref_name: ${{ github.event.pull_request.head.ref || github.ref }}
         variables: |
-          GITHUB_REPOSITORY=${{ github.repository }}
-          GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
-          GITHUB_PR=${{ github.event.pull_request.number }}
-          PIPELINE_NAME=${{ github.repository }}: ${{ github.event.pull_request.title || github.ref_name }}
+          GITHUB_REPOSITORY=${{ inputs.SOURCE_REPOSITORY || github.repository }}
+          GITHUB_SHA=${{ inputs.SOURCE_SHA || github.event.pull_request.head.sha || github.sha }}
+          GITHUB_PR=${{ inputs.SOURCE_PR || github.event.pull_request.number }}
+          PIPELINE_NAME=${{ inputs.SOURCE_REPOSITORY || github.repository }}: ${{ inputs.SOURCE_TITLE || github.event.pull_request.title || github.ref_name }}
           COMMON_BENCH_VERSION=${{ inputs.COMMON_BENCH_VERSION }}
     - name: Set pending EICweb status
-      if: ${{ github.event_name != 'delete' }}
+      if: ${{ github.event_name != 'delete' && inputs.SOURCE_SHA == '' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DETECTOR_CONFIG: epic_craterlake


### PR DESCRIPTION
When `mirror.yaml` is triggered via `workflow_dispatch` (e.g. from `eic/common_bench`), pass `SOURCE_REPOSITORY` and `SOURCE_SHA` so that the GitLab CI pipeline posts its pending/success/failure statuses back to the originating repository and commit rather than to the benchmark repo's own master commit.

The GitHub-side 'Set pending EICweb status' step is skipped when `SOURCE_SHA` is provided, since the GitLab pipeline's own `benchmarks:pending` job handles that notification.

Mirrors [eic/physics_benchmarks#97](https://github.com/eic/physics_benchmarks/pull/97).

### What kind of change does this PR introduce?
- [x] New feature (issue #__)

### Please check if any of the following apply
- [ ] This PR introduces breaking changes.
- [ ] This PR changes default behavior.
- [x] AI was used in preparing this PR.