### PR TITLE
common:setup: clone common_bench directly to .local, drop install_common.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,7 @@ common:setup:
       echo "COMMON_BENCH_VERSION = ${COMMON_BENCH_VERSION}" 
       echo "COMMON_BENCH_VERSION=${COMMON_BENCH_VERSION}" >> .env
       git clone -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local 
+      rm -rf .local/.git
       echo "BENCHMARKS_TAG: ${BENCHMARKS_TAG}"
       echo "BENCHMARKS_CONTAINER: ${BENCHMARKS_CONTAINER}"
       echo "BENCHMARKS_REGISTRY: ${BENCHMARKS_REGISTRY}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,11 +89,11 @@ common:setup:
       fi
       echo "COMMON_BENCH_VERSION = ${COMMON_BENCH_VERSION}" 
       echo "COMMON_BENCH_VERSION=${COMMON_BENCH_VERSION}" >> .env
-      git clone -b "${COMMON_BENCH_VERSION}" https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git setup 
+      git clone -b "${COMMON_BENCH_VERSION}" https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git .local 
       echo "BENCHMARKS_TAG: ${BENCHMARKS_TAG}"
       echo "BENCHMARKS_CONTAINER: ${BENCHMARKS_CONTAINER}"
       echo "BENCHMARKS_REGISTRY: ${BENCHMARKS_REGISTRY}"
-    - source setup/bin/env.sh && ./setup/bin/install_common.sh
+    - source .local/bin/env.sh
     - mkdir_local_data_link sim_output
     - mkdir -p results
     - mkdir -p config

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ common:setup:
       fi
       echo "COMMON_BENCH_VERSION = ${COMMON_BENCH_VERSION}" 
       echo "COMMON_BENCH_VERSION=${COMMON_BENCH_VERSION}" >> .env
-      git clone -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local 
+      git clone --depth 1 -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local 
       rm -rf .local/.git
       echo "BENCHMARKS_TAG: ${BENCHMARKS_TAG}"
       echo "BENCHMARKS_CONTAINER: ${BENCHMARKS_CONTAINER}"


### PR DESCRIPTION
## Summary

`install_common.sh` exists solely to copy `setup/ → .local/`. All downstream jobs already source `.local/bin/env.sh` — `setup/` is never an artifact.

By cloning directly to `.local/`, the separate copy step is eliminated and `install_common.sh` becomes dead code.

### Change

```diff
- git clone -b "${COMMON_BENCH_VERSION}" .../common_bench.git setup
- source setup/bin/env.sh && ./setup/bin/install_common.sh
+ git clone -b "${COMMON_BENCH_VERSION}" .../common_bench.git .local
+ source .local/bin/env.sh
```

No downstream jobs are affected — they all already source `.local/bin/env.sh`.