### PR TITLE
common:setup: remove print_env.sh call

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,7 +97,6 @@ common:setup:
     - mkdir_local_data_link sim_output
     - mkdir -p results
     - mkdir -p config
-    - print_env.sh
     - eic-info
     - |
       flock --nonblock /scratch/garbage-collect.lock \


### PR DESCRIPTION
## Summary

`print_env.sh` is a debugging aid in `common_bench` that prints environment variables. It includes several variables (`DETECTOR_PREFIX`, `BEAMLINE`, `BEAMLINE_CONFIG`, `BEAMLINE_VERSION`) that were already removed from `env.sh` (see eic/common_bench#2), so it currently prints empty lines for those.

The CI job log already captures all variable assignments, and `eic-info` provides the relevant software version information. The `print_env.sh` call adds noise without value.

Part of the ongoing `common_bench` cleanup series.