### PR TITLE
fix: sim:beamline: add `--printLevel WARNING` to limit logging

### DIFF
--- a/benchmarks/beamline/Snakefile
+++ b/benchmarks/beamline/Snakefile
@@ -76,6 +76,7 @@ rule beamline_acceptance_sim:
             --enableG4GPS \
             --macroFile {input.macro} \
             --compactFile $DETECTOR_PATH/epic_ip6_extended.xml \
+            --printLevel WARNING \
             --outputFile {output} \
             --physics.rangecut 100*m
         """


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds `--printLevel WARNING` to `sim:beamline` to avoid excessive logging (e.g. https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7695817). This applies to acceptance what is already done for beamline.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7695817)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
