### PR TITLE
fix: create EPIC/ like sim_output/, for steer and evgen files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,7 @@ common:setup:
       echo "BENCHMARKS_REGISTRY: ${BENCHMARKS_REGISTRY}"
     - source .local/bin/env.sh
     - mkdir_local_data_link sim_output
+    - mkdir_local_data_link EPIC
     - mkdir -p results
     - mkdir -p config
     - eic-info
@@ -112,6 +113,7 @@ common:setup:
     - source /opt/detector/epic-main/bin/thisepic.sh
     - ls -lrtha 
     - ln -s "${LOCAL_DATA_PATH}/sim_output" sim_output
+    - ln -s "${LOCAL_DATA_PATH}/EPIC" EPIC
     # snakemake support
     - mkdir "${DETECTOR_CONFIG}"
     - ln -s "${LOCAL_DATA_PATH}/sim_output" "${DETECTOR_CONFIG}/sim_output"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR ensures that there is an EPIC under /scratch to avoid garbage collecting steer files midflight.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: garbage-collect.py requires /scratch base for alive files)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

AI diagnosis, human fix.

This seems to cause failures of 3h sim:ecal_backwards jobs, which keep runners busy for no reason.