### PR TITLE
fix: split nhcal_basic_distribution_full further

### DIFF
--- a/benchmarks/nhcal_basic_distribution/config.yml
+++ b/benchmarks/nhcal_basic_distribution/config.yml
@@ -15,7 +15,7 @@ sim:nhcal_basic_distribution_full:
   timeout: 4 hours
   parallel:
     matrix:
-      - ENERGY: ["0.5", "0.7", "1.0", "2.0"]
+      - ENERGY: ["0.5", "0.7", "1.0"]
         INDEX_RANGE: ["0 4", "5 9"]
       - ENERGY: ["2.0"]
         INDEX_RANGE: ["0 3", "4 7", "8 9"]

--- a/benchmarks/nhcal_basic_distribution/config.yml
+++ b/benchmarks/nhcal_basic_distribution/config.yml
@@ -16,9 +16,11 @@ sim:nhcal_basic_distribution_full:
   parallel:
     matrix:
       - ENERGY: ["0.5", "0.7", "1.0", "2.0"]
-        INDEX_RANGE: ["0 4","5 9"]
+        INDEX_RANGE: ["0 4", "5 9"]
+      - ENERGY: ["2.0"]
+        INDEX_RANGE: ["0 3", "4 7", "8 9"]
       - ENERGY: ["5.0"]
-        INDEX_RANGE: ["0 2", "3 5", "6 7", "8 9"]
+        INDEX_RANGE: ["0 1", "2 3", "4 5", "6 7", "8 9"]
 
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB --retries 1 $(for INDEX in $(seq $INDEX_RANGE); do echo sim_output/nhcal_basic_distribution/E${ENERGY}GeV/sim_epic_full.${INDEX}.edm4hep.root; done)


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR splits the longest running simulation jobs into smaller chunks for better throughput.
<img width="1208" height="487" alt="image" src="https://github.com/user-attachments/assets/66f9c22d-1645-4a72-9370-900d545ed2f1" />

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: long running jobs limit throughput)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
