### PR TITLE
fix: rm hardcoded versioned/hashed paths in g++ command

### DIFF
--- a/benchmarks/nhcal_sampling_fraction/Snakefile
+++ b/benchmarks/nhcal_sampling_fraction/Snakefile
@@ -70,9 +70,7 @@ rule nhcal_sampling_fraction_analysis:
         g++ {input.script} \
             $(root-config --cflags --libs) \
             -I/opt/local/include \
-            -I/opt/local/include/python3.13 \
             -L/opt/local/lib \
-            -L/opt/software/linux-x86_64_v2/dd4hep-1.34-seyysegqve2ztvnksz3kokjy4ugwip65/lib \
             -lpodio -lpodioRootIO -ledm4hep -lDDCore -lDDRec \
             -o {output.pdf}.bin && \
         {output.pdf}.bin "{input.combined}" "{output.pdf}" "{output.png}" "{params.DETECTOR_PATH}/{params.DETECTOR_CONFIG}" && \

--- a/benchmarks/nhcal_sampling_fraction/Snakefile
+++ b/benchmarks/nhcal_sampling_fraction/Snakefile
@@ -69,6 +69,7 @@ rule nhcal_sampling_fraction_analysis:
         """
         g++ {input.script} \
             $(root-config --cflags --libs) \
+            $(python-config --includes) \
             -I/opt/local/include \
             -L/opt/local/lib \
             -lpodio -lpodioRootIO -ledm4hep -lDDCore -lDDRec \


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes two hardcoded versioned/hashed paths in a g++ command that are unlikely to be stable (the DD4hep path is already invalid).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
