### PR TITLE
fix: rm artifact paths .local/{detector,share}

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,11 +24,9 @@ default:
   artifacts:
     expire_in: 72 hours 
     paths:
-      - .local/detector
       - .local/lib
       - .local/bin
       - .local/include
-      - .local/share
       - .snakemake/log
       - logs
       - results


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
After the common_bench cleanup, we don't have `.local/{detector,share}` anymore (`.local/lib` is still used to write a dRICH benchmark shared object library). This removes the noise attempts at uploading these directories in the artifacts.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: tech debt)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
