### PR TITLE
fix: deploy_results extends .det_benchmark to get DETECTOR_PATH

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,6 +165,7 @@ include:
   
 deploy_results:
   allow_failure: true
+  extends: .det_benchmark
   stage: deploy
   needs:
     - "collect_results:backgrounds"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
In order to parse `snakemake $SNAKEMAKE_FLAGS --cores 1 results/metadata.json` in `deploy_results` (which is `allow_fail: true` so this wasn't noticed) we need to ensure all `os.environ["DETECTOR_PATH"]` etc in the Snakefiles are parsing fine. Otherwise we end up with `KeyError` as in e.g. https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7803198#L110. This probably stopped working when we removed `DETECTOR_PATH` from the `.env` propagation between jobs in `common_bench`.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: new failures in allow_fail jobs)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
