### PR TITLE
tracking_performances: put temp file under tracking_performances/

### DIFF
--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -121,7 +121,7 @@ rule tracking_performance_at_momentum:
     output:
         "{CAMPAIGN}/{SEEDING}/pi-/mom/Performances_mom_{MOMENTUM}_mom_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
         "{CAMPAIGN}/{SEEDING}/pi-/dca/Performances_dca_{MOMENTUM}_dca_resol_{SEEDING_IGNORE}_{PARTICLE}.root",
-        combined_root=temp("{CAMPAIGN}/sim_{SEEDING}_{MOMENTUM}_{SEEDING_IGNORE}_{PARTICLE}.root"),
+        combined_root=temp("tracking_performances/{CAMPAIGN}/sim_{SEEDING}_{MOMENTUM}_{SEEDING_IGNORE}_{PARTICLE}.root"),
     shell:
         """
 if [[ "{wildcards.SEEDING}" == "truthseed" ]]; then


### PR DESCRIPTION
The wildcard for `*/sim_*_*_*_*.root` is not sufficiently restrictive, leading to false positives in matching.