### PR TITLE
fix: prefer system pelican before download

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,11 +204,15 @@ deploy_results:
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 results/metadata.json
     - find results -print | sort | tee summary.txt
-    - wget https://dl.pelicanplatform.org/7.13.0/pelican_Linux_x86_64.tar.gz
-    - sha256sum -c <(echo '38ac8548c67302299e50a1b81c159ed418e90d84a6606ddd377fd2c8b164d114  pelican_Linux_x86_64.tar.gz')
-    - tar zxf pelican_Linux_x86_64.tar.gz
+    - |
+      if [ ! -x "$(command -v pelican)" ] ; then
+        wget https://dl.pelicanplatform.org/7.13.0/pelican_Linux_x86_64.tar.gz ;
+        sha256sum -c <(echo '38ac8548c67302299e50a1b81c159ed418e90d84a6606ddd377fd2c8b164d114 pelican_Linux_x86_64.tar.gz') ;
+        tar zxf pelican_Linux_x86_64.tar.gz ;
+        export PATH=${PWD}/pelican-7.13.0:${PATH} ;
+      fi
     - mv results pipeline-$CI_PIPELINE_ID; tar cf pipeline-$CI_PIPELINE_ID.tar pipeline-$CI_PIPELINE_ID/; mv pipeline-$CI_PIPELINE_ID results
-    - ./pelican-*/pelican object copy pipeline-$CI_PIPELINE_ID.tar $OSDF_ENDPOINT$OSDF_OUTPUT_PREFIX/pipeline-$CI_PIPELINE_ID.tar
+    - pelican object copy pipeline-$CI_PIPELINE_ID.tar $OSDF_ENDPOINT$OSDF_OUTPUT_PREFIX/pipeline-$CI_PIPELINE_ID.tar
   retry:
     max: 2
     when:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR modifies the deploy_results to use the system pelican over the downloaded one. This will typically mean no download needed (unless used with old container releases that don't contain system pelican; which is why fallback is retained).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: use system when possible)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.