### PR TITLE
fix: prevent bench:backwards_ecal and bench:calo_pid from running sims

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,11 +204,15 @@ deploy_results:
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 results/metadata.json
     - find results -print | sort | tee summary.txt
-    - wget https://dl.pelicanplatform.org/7.13.0/pelican_Linux_x86_64.tar.gz
-    - sha256sum -c <(echo '38ac8548c67302299e50a1b81c159ed418e90d84a6606ddd377fd2c8b164d114  pelican_Linux_x86_64.tar.gz')
-    - tar zxf pelican_Linux_x86_64.tar.gz
+    - |
+      if [ ! -x "$(command -v pelican)" ] ; then
+        wget https://dl.pelicanplatform.org/7.13.0/pelican_Linux_x86_64.tar.gz ;
+        sha256sum -c <(echo '38ac8548c67302299e50a1b81c159ed418e90d84a6606ddd377fd2c8b164d114 pelican_Linux_x86_64.tar.gz') ;
+        tar zxf pelican_Linux_x86_64.tar.gz ;
+        export PATH=${PWD}/pelican-7.13.0:${PATH} ;
+      fi
     - mv results pipeline-$CI_PIPELINE_ID; tar cf pipeline-$CI_PIPELINE_ID.tar pipeline-$CI_PIPELINE_ID/; mv pipeline-$CI_PIPELINE_ID results
-    - ./pelican-*/pelican object copy pipeline-$CI_PIPELINE_ID.tar $OSDF_ENDPOINT$OSDF_OUTPUT_PREFIX/pipeline-$CI_PIPELINE_ID.tar
+    - pelican object copy pipeline-$CI_PIPELINE_ID.tar $OSDF_ENDPOINT$OSDF_OUTPUT_PREFIX/pipeline-$CI_PIPELINE_ID.tar
   retry:
     max: 2
     when:

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -28,7 +28,7 @@ bench:backwards_ecal:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backwards_ecal/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/local
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB --allowed-rules backwards_ecal matplotlibrc results/backwards_ecal/local
 
 bench:backwards_ecal_campaigns:
   extends: .det_benchmark

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -28,7 +28,7 @@ bench:backwards_ecal:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backwards_ecal/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB --allowed-rules backwards_ecal matplotlibrc results/backwards_ecal/local
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/local --allowed-rules backwards_ecal matplotlibrc
 
 bench:backwards_ecal_campaigns:
   extends: .det_benchmark

--- a/benchmarks/backwards_ecal/config.yml
+++ b/benchmarks/backwards_ecal/config.yml
@@ -28,7 +28,7 @@ bench:backwards_ecal:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/backwards_ecal/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/local --allowed-rules backwards_ecal matplotlibrc
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB results/backwards_ecal/local --allowed-rules backwards_ecal_local_sim_list backwards_ecal matplotlibrc org2py
 
 bench:backwards_ecal_campaigns:
   extends: .det_benchmark

--- a/benchmarks/calo_pid/config.yml
+++ b/benchmarks/calo_pid/config.yml
@@ -29,7 +29,7 @@ bench:calo_pid:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/calo_pid/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_inner_detector/calo_pid --allowed-rules calo_pid matplotlibrc
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_inner_detector/calo_pid --allowed-rules calo_pid_input_list calo_pid matplotlibrc org2py
 
 collect_results:calo_pid:
   extends: .det_benchmark

--- a/benchmarks/calo_pid/config.yml
+++ b/benchmarks/calo_pid/config.yml
@@ -29,7 +29,7 @@ bench:calo_pid:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/calo_pid/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_inner_detector/calo_pid
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 --allowed-rules calo_pid matplotlibrc results/epic_inner_detector/calo_pid
 
 collect_results:calo_pid:
   extends: .det_benchmark

--- a/benchmarks/calo_pid/config.yml
+++ b/benchmarks/calo_pid/config.yml
@@ -29,7 +29,7 @@ bench:calo_pid:
   script:
     - export PYTHONUSERBASE=$LOCAL_DATA_PATH/deps
     - pip install -r benchmarks/calo_pid/requirements.txt
-    - snakemake $SNAKEMAKE_FLAGS --cores 1 --allowed-rules calo_pid matplotlibrc results/epic_inner_detector/calo_pid
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 results/epic_inner_detector/calo_pid --allowed-rules calo_pid matplotlibrc
 
 collect_results:calo_pid:
   extends: .det_benchmark


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR uses `--allowed-rules` with the specified rule only to prevent `bench:backwards_ecal` and `bench:calo_pid` from running simulations when they have been garbage collected prematurely. This ensures fast failures instead of long simulations before timeouts.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: job timeouts when missing inputs)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
