### PR TITLE
lfhcal,tracking_performances: use direct script paths

### DIFF
--- a/benchmarks/lfhcal/LFHCAL_Performance.C
+++ b/benchmarks/lfhcal/LFHCAL_Performance.C
@@ -12,7 +12,7 @@
 
 #define mpi 0.139  // 1.864 GeV/c^2
 
-void LFHCAL_Performance(TString filename="tracking_output",TString particle="pi-", double mom=0.1, Double_t pTcut = 0.0, TString name = "")
+void LFHCAL_Performance(TString filename="tracking_output",TString particle="pi-", double mom=0.1, Double_t pTcut = 0.0, TString name = "", TString output_dir=".")
 {
 
   // style of the plot
@@ -144,7 +144,7 @@ void LFHCAL_Performance(TString filename="tracking_output",TString particle="pi-
   
     }// event loop ends    
   
-   TFile *fout_mom = new TFile(Form("%s/mom/lfhcal_mom_%1.1f_%s_%s.root",particle.Data(),mom,dist_dir_mom.Data(),particle.Data()),"recreate");
+   TFile *fout_mom = new TFile(Form("%s/%s/mom/lfhcal_mom_%1.1f_%s_%s.root",output_dir.Data(),particle.Data(),mom,dist_dir_mom.Data(),particle.Data()),"recreate");
    fout_mom->cd();
    for (int ibin=0; ibin<nbins_eta; ++ibin) histp[ibin]->Write();
    fout_mom->Close();

--- a/benchmarks/lfhcal/Snakefile
+++ b/benchmarks/lfhcal/Snakefile
@@ -85,8 +85,7 @@ rule lfhcal_at_momentum:
     shell:
         """
 hadd {output.combined_root} {input.sim}
-cd {wildcards.CAMPAIGN}
-root -l -b -q ../{input.script}'("../{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15)'
+root -l -b -q {input.script}'("{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, "", "{wildcards.CAMPAIGN}")'
 """
 
 rule lfhcal_summary_at_eta:
@@ -117,8 +116,7 @@ if [[ "{wildcards.CAMPAIGN}" == "local" ]]; then
 else
         EXTRA_LEGEND="ePIC Simulation {wildcards.CAMPAIGN}"
 fi
-cd {wildcards.CAMPAIGN}
-root -l -b -q ../{input.script}'("{wildcards.PARTICLE}", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1., true, "'"$EXTRA_LEGEND"'")'
+root -l -b -q {input.script}'("{wildcards.PARTICLE}", {wildcards.ETA_MIN}, {wildcards.ETA_MAX}, 1., true, "'"$EXTRA_LEGEND"'", "{wildcards.CAMPAIGN}")'
 """
 
 LFHCAL_ETA_BINS = [1.2,1.5,2,2.5,3,3.5]

--- a/benchmarks/lfhcal/doCompare_widebins_mom.C
+++ b/benchmarks/lfhcal/doCompare_widebins_mom.C
@@ -10,7 +10,7 @@
 #define mpi 0.139  // 1.864 GeV/c^2
 
 //void draw_req_Mom(double etamin, double etamax, double xmin=0., double xmax=0.);
-void doCompare_widebins_mom(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, double range =0.3, Bool_t drawreq=1, TString extra_legend = "") // name = p, pt for getting p or pt dependence fitted results
+void doCompare_widebins_mom(TString particle = "pi-",double etamin=-1.0, double etamax=1.0, double range =0.3, Bool_t drawreq=1, TString extra_legend = "", TString output_dir=".") // name = p, pt for getting p or pt dependence fitted results
 {
   
   //=== style of the plot=========
@@ -62,7 +62,7 @@ void doCompare_widebins_mom(TString particle = "pi-",double etamin=-1.0, double 
     cp->SetMargin(0.10, 0.05 ,0.1,0.07);
 
     //pi-/mom/lfhcal_mom_20.0_mom_resol_pi-.root
-    fmom[i] = TFile::Open(Form("./%s/mom/lfhcal_mom_%1.1f_mom_resol_%s.root",particle.Data(),mom[i],particle.Data()));
+    fmom[i] = TFile::Open(Form("%s/%s/mom/lfhcal_mom_%1.1f_mom_resol_%s.root",output_dir.Data(),particle.Data(),mom[i],particle.Data()));
     
     TH1D *hist = (TH1D*) fmom[i]->Get(Form("hist_mom_%1.1f_%1.1f_pmax_%1.1f",mom[i],etamin,etamax));
     hist->Rebin(2);
@@ -103,7 +103,7 @@ void doCompare_widebins_mom(TString particle = "pi-",double etamin=-1.0, double 
   }
   
   
-  TFile *fout = new TFile(Form("Final_Results/%s/mom/lfhcal_mom_resol_%s_%1.1f_eta_%1.1f.root",particle.Data(),particle.Data(),etamin,etamax),"recreate");
+  TFile *fout = new TFile(Form("%s/Final_Results/%s/mom/lfhcal_mom_resol_%s_%1.1f_eta_%1.1f.root",output_dir.Data(),particle.Data(),particle.Data(),etamin,etamax),"recreate");
   TGraphErrors *gr1 = new TGraphErrors(size,p,sigma_p,err_p,err_sigma_p);
   gr1->SetName("grseed");
   gr1->SetMarkerStyle(25);
@@ -122,7 +122,7 @@ void doCompare_widebins_mom(TString particle = "pi-",double etamin=-1.0, double 
   lmom->AddEntry(gr1,"Nominal");
   lmom->Draw("same");
   //draw_req_Mom(etamin,etamax,0.,mgMom->GetXaxis()->GetXmax());
-  c_mom->SaveAs(Form("Final_Results/%s/mom/lfhcal_mom_resol_%s_%1.1f_eta_%1.1f.png",particle.Data(),particle.Data(),etamin,etamax));
+  c_mom->SaveAs(Form("%s/Final_Results/%s/mom/lfhcal_mom_resol_%s_%1.1f_eta_%1.1f.png",output_dir.Data(),particle.Data(),particle.Data(),etamin,etamax));
   
   // Write the numbers in output file for comparisons
   outfile << extra_legend << endl;

--- a/benchmarks/tracking_performances/Snakefile
+++ b/benchmarks/tracking_performances/Snakefile
@@ -130,8 +130,7 @@ elif [[ "{wildcards.SEEDING}" == "realseed" ]]; then
         TRUTH_SEEDING="false"
 fi
 hadd {output.combined_root} {input.sim}
-cd {wildcards.CAMPAIGN}
-root -l -b -q ../{input.script}'("../{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, '$TRUTH_SEEDING')'
+root -l -b -q {input.script}'("{output.combined_root}", "{wildcards.PARTICLE}", {wildcards.MOMENTUM}, 0.15, '$TRUTH_SEEDING', "{wildcards.CAMPAIGN}")'
 """
 
 

--- a/benchmarks/tracking_performances/Tracking_Performances.C
+++ b/benchmarks/tracking_performances/Tracking_Performances.C
@@ -11,7 +11,7 @@
 #include "TMath.h"
 #define mpi 0.139  // 1.864 GeV/c^2
 
-void Tracking_Performances(TString filename="tracking_output",TString particle="pi-", double mom=0.1, Double_t pTcut = 0.15, bool truth_seeding=false)
+void Tracking_Performances(TString filename="tracking_output",TString particle="pi-", double mom=0.1, Double_t pTcut = 0.15, bool truth_seeding=false, TString output_dir=".")
 {
 
   // style of the plot
@@ -162,7 +162,7 @@ void Tracking_Performances(TString filename="tracking_output",TString particle="
        
    }// event loop ends    
   
-   TFile *fout_mom = new TFile(Form("%s/%s/mom/Performances_mom_%1.1f_%s_%s.root",dir.Data(),particle.Data(),mom,dist_dir_mom.Data(),particle.Data()),"recreate");
+   TFile *fout_mom = new TFile(Form("%s/%s/%s/mom/Performances_mom_%1.1f_%s_%s.root",output_dir.Data(),dir.Data(),particle.Data(),mom,dist_dir_mom.Data(),particle.Data()),"recreate");
    fout_mom->cd();
    for (int ibin=0; ibin<nbins_eta; ++ibin){
    histp[ibin]->Write();
@@ -174,7 +174,7 @@ void Tracking_Performances(TString filename="tracking_output",TString particle="
    }
    fout_mom->Close();
 
-   TFile *fout_dca = new TFile(Form("%s/%s/dca/Performances_dca_%1.1f_%s_%s.root",dir.Data(),particle.Data(),mom,dist_dir_dca.Data(),particle.Data()),"recreate");
+   TFile *fout_dca = new TFile(Form("%s/%s/%s/dca/Performances_dca_%1.1f_%s_%s.root",output_dir.Data(),dir.Data(),particle.Data(),mom,dist_dir_dca.Data(),particle.Data()),"recreate");
    fout_dca->cd();
     h_d0xy_3d->Write();
     h_d0z_3d->Write();


### PR DESCRIPTION
This avoids Snakemake antipattern of `cd dir; root ../{input.script}` (where script may become an absolute path in Snakemake).