### PR TITLE
feat: add campaign mode for DIS tracking benchmarks via BNL xrootd 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,6 +186,7 @@ deploy_results:
     - "collect_results:zdc_lambda"
     - "collect_results:insert_neutron"
     - "collect_results:tracking_performances_dis"
+    - "collect_results:tracking_performances_dis:campaign"
     - "collect_results:zdc"
     - "collect_results:zdc_lyso"
     - "collect_results:zdc_neutron"

--- a/Snakefile
+++ b/Snakefile
@@ -107,7 +107,6 @@ echo 'Unexpected value for config["remote_provider"]: {config["remote_provider"]
 exit 1
 """
 
-
 rule warmup_run:
     output:
         "warmup.edm4hep.root",

--- a/benchmarks/tracking_performances_dis/Snakefile
+++ b/benchmarks/tracking_performances_dis/Snakefile
@@ -1,5 +1,14 @@
 import os
 
+# Campaign configuration defaults — override via snakemake --config or CI variables
+# (CI yml passes these via snakemake --config dis_campaign=... etc.)
+DIS_CAMPAIGN_CONFIG = {
+    "campaign": config.get("dis_campaign", "26.05.0"),
+    "beam":     config.get("dis_beam",     "9x130"),
+    "q2_range": config.get("dis_q2_range", "q2_10to100"),
+    "nfiles":   int(config.get("dis_nfiles", 5)),
+}
+
 rule trk_dis_compile:
     input:
         "benchmarks/tracking_performances_dis/analysis/trk_dis_analysis_cxx.so",
@@ -191,6 +200,174 @@ rule vtx_dis_plots:
 root -l -b -q '{input.script}+("{input.config}")'
 """
 
+# Campaign mode: stream pre-reconstructed files directly from BNL xrootd
+# ROOT TChain supports xrootd URLs natively — no local copy needed
+rule dis_campaign_analysis:
+    input:
+        script_trk="benchmarks/tracking_performances_dis/analysis/trk_dis_analysis.cxx",
+        script_trk_compiled="benchmarks/tracking_performances_dis/analysis/trk_dis_analysis_cxx.so",
+        script_vtx="benchmarks/tracking_performances_dis/analysis/vtx_dis_analysis.cxx",
+        script_vtx_compiled="benchmarks/tracking_performances_dis/analysis/vtx_dis_analysis_cxx.so",
+    output:
+        config_trk="results/tracking_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/{STEM}/config.json",
+        hists_trk="results/tracking_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/{STEM}/hists.root",
+        config_vtx="results/vertexing_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/{STEM}/config.json",
+        hists_vtx="results/vertexing_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/{STEM}/hists.root",
+    wildcard_constraints:
+        CAMPAIGN=r"[\d.]+",
+        BEAM=r"\d+x\d+",
+        Q2_RANGE=r"q2_\w+",
+        STEM=r"(?!combined_)\S+",
+    params:
+        EBEAM=lambda wildcards: wildcards.BEAM.split("x")[0],
+        PBEAM=lambda wildcards: wildcards.BEAM.split("x")[1],
+        MINQ2=lambda wildcards: wildcards.Q2_RANGE.split("_")[1].split("to")[0],
+        xrd_url="root://epicxrd1.sdcc.bnl.gov:1095//eic/EPIC/RECO/{CAMPAIGN}/epic_craterlake/DIS/pythia8.316-1.0/NC/noRad/ep/{BEAM}/{Q2_RANGE}/{STEM}.eicrecon.edm4eic.root",
+    shell:
+        """
+cat > {output.config_trk} <<EOF
+{{
+  "rec_file": "{params.xrd_url}",
+  "detector": "epic_craterlake",
+  "ebeam": {params.EBEAM},
+  "pbeam": {params.PBEAM},
+  "Min_Q2": {params.MINQ2},
+  "output_prefix": "$(dirname "{output.hists_trk}")/hists"
+}}
+EOF
+root -l -b -q '{input.script_trk}+("{output.config_trk}")'
+
+cat > {output.config_vtx} <<EOF
+{{
+  "rec_file": "{params.xrd_url}",
+  "detector": "epic_craterlake",
+  "ebeam": {params.EBEAM},
+  "pbeam": {params.PBEAM},
+  "Min_Q2": {params.MINQ2},
+  "output_prefix": "$(dirname "{output.hists_vtx}")/hists"
+}}
+EOF
+root -l -b -q '{input.script_vtx}+("{output.config_vtx}")'
+"""
+
+checkpoint dis_campaign_sim_list:
+    output:
+        "listing/tracking_performances_dis/{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}.lst",
+    params:
+        search_path=lambda wildcards: f"RECO/{wildcards.CAMPAIGN}/epic_craterlake/DIS/pythia8.316-1.0/NC/noRad/ep/{wildcards.BEAM}/{wildcards.Q2_RANGE}/",
+    wildcard_constraints:
+        CAMPAIGN=r"[\d.]+",
+        BEAM=r"\d+x\d+",
+        Q2_RANGE=r"q2_\w+",
+    shell:
+        """
+xrdfs root://epicxrd1.sdcc.bnl.gov:1095/ ls /eic/EPIC/{params.search_path} \
+  | grep '\.eicrecon\.edm4eic\.root$' \
+  | sed 's|.*/||; s|\.eicrecon\.edm4eic\.root$||' \
+  | sort \
+  > {output}
+if [ ! -s {output} ]; then
+  echo "Empty file listing for path /eic/EPIC/{params.search_path}"
+  exit 1
+fi
+"""
+
+def _dis_campaign_stems(wildcards):
+    listing = checkpoints.dis_campaign_sim_list.get(
+        CAMPAIGN=wildcards.CAMPAIGN,
+        BEAM=wildcards.BEAM,
+        Q2_RANGE=wildcards.Q2_RANGE,
+    ).output[0]
+    with open(listing) as f:
+        return [line.strip() for line in f if line.strip()]
+
+rule dis_campaign_combine:
+    input:
+        trk=lambda wildcards: [
+            f"results/tracking_performances_dis/campaign_{wildcards.CAMPAIGN}/epic_craterlake/{wildcards.BEAM}/{wildcards.Q2_RANGE}/{stem}/hists.root"
+            for stem in _dis_campaign_stems(wildcards)[:int(wildcards.NFILES)]
+        ],
+        vtx=lambda wildcards: [
+            f"results/vertexing_performances_dis/campaign_{wildcards.CAMPAIGN}/epic_craterlake/{wildcards.BEAM}/{wildcards.Q2_RANGE}/{stem}/hists.root"
+            for stem in _dis_campaign_stems(wildcards)[:int(wildcards.NFILES)]
+        ],
+    output:
+        config_trk="results/tracking_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/config.json",
+        hists_trk="results/tracking_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/hists.root",
+        config_vtx="results/vertexing_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/config.json",
+        hists_vtx="results/vertexing_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/hists.root",
+    wildcard_constraints:
+        CAMPAIGN=r"[\d.]+",
+        BEAM=r"\d+x\d+",
+        Q2_RANGE=r"q2_\w+",
+        NFILES=r"\d+",
+    params:
+        EBEAM=lambda wildcards: wildcards.BEAM.split("x")[0],
+        PBEAM=lambda wildcards: wildcards.BEAM.split("x")[1],
+        MINQ2=lambda wildcards: wildcards.Q2_RANGE.split("_")[1].split("to")[0],
+    shell:
+        """
+cat > {output.config_trk} <<EOF
+{{
+  "hists_file": "{output.hists_trk}",
+  "detector": "epic_craterlake",
+  "ebeam": {params.EBEAM},
+  "pbeam": {params.PBEAM},
+  "Min_Q2": {params.MINQ2},
+  "nfiles": {wildcards.NFILES},
+  "output_prefix": "$(dirname "{output.hists_trk}")/plots"
+}}
+EOF
+hadd {output.hists_trk} {input.trk}
+
+cat > {output.config_vtx} <<EOF
+{{
+  "hists_file": "{output.hists_vtx}",
+  "detector": "epic_craterlake",
+  "ebeam": {params.EBEAM},
+  "pbeam": {params.PBEAM},
+  "Min_Q2": {params.MINQ2},
+  "nfiles": {wildcards.NFILES},
+  "output_prefix": "$(dirname "{output.hists_vtx}")/plots"
+}}
+EOF
+hadd {output.hists_vtx} {input.vtx}
+"""
+
+rule trk_dis_campaign_plots:
+    input:
+        script="benchmarks/tracking_performances_dis/analysis/trk_dis_plots.cxx",
+        script_compiled="benchmarks/tracking_performances_dis/analysis/trk_dis_plots_cxx.so",
+        config="results/tracking_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/config.json",
+    output:
+        "results/tracking_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/plots.pdf",
+    wildcard_constraints:
+        CAMPAIGN=r"[\d.]+",
+        BEAM=r"\d+x\d+",
+        Q2_RANGE=r"q2_\w+",
+        NFILES=r"\d+",
+    shell:
+        """
+root -l -b -q '{input.script}+("{input.config}")'
+"""
+
+rule vtx_dis_campaign_plots:
+    input:
+        script="benchmarks/tracking_performances_dis/analysis/vtx_dis_plots.cxx",
+        script_compiled="benchmarks/tracking_performances_dis/analysis/vtx_dis_plots_cxx.so",
+        config="results/vertexing_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/config.json",
+    output:
+        "results/vertexing_performances_dis/campaign_{CAMPAIGN}/epic_craterlake/{BEAM}/{Q2_RANGE}/combined_{NFILES}/plots.pdf",
+    wildcard_constraints:
+        CAMPAIGN=r"[\d.]+",
+        BEAM=r"\d+x\d+",
+        Q2_RANGE=r"q2_\w+",
+        NFILES=r"\d+",
+    shell:
+        """
+root -l -b -q '{input.script}+("{input.config}")'
+"""
+
 #Examples of invocation
 rule trk_dis_run_locally:
     input:
@@ -215,5 +392,24 @@ rule trk_dis_run_locally_trk_only:
 rule vtx_dis_run_locally_trk_only:
     input:
         "results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plots.pdf",
+    message:
+        "See output in {input[0]}"
+
+
+# Campaign invocation rules (pre-simulated files from BNL xrootd)
+# To switch campaigns, update DIS_CAMPAIGN_CONFIG at the top of this file.
+rule trk_dis_campaign:
+    input:
+        "results/tracking_performances_dis/campaign_{campaign}/epic_craterlake/{beam}/{q2_range}/combined_{nfiles}/plots.pdf".format(
+            **DIS_CAMPAIGN_CONFIG
+        ),
+    message:
+        "See output in {input[0]}"
+
+rule vtx_dis_campaign:
+    input:
+        "results/vertexing_performances_dis/campaign_{campaign}/epic_craterlake/{beam}/{q2_range}/combined_{nfiles}/plots.pdf".format(
+            **DIS_CAMPAIGN_CONFIG
+        ),
     message:
         "See output in {input[0]}"

--- a/benchmarks/tracking_performances_dis/config.yml
+++ b/benchmarks/tracking_performances_dis/config.yml
@@ -41,4 +41,56 @@ collect_results:tracking_performances_dis:
       gs -sDEVICE=pngalpha -dUseCropBox -r144 \
         -o 'results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/vertexing_performances_dis_%03d.png' \
         results/vertexing_performances_dis/epic_craterlake_tracking_only/pythia8NCDIS_18x275_minQ2=1_combined_5/plots.pdf
-        
+
+# Campaign jobs using pre-reconstructed files from BNL xrootd (epicxrd1.sdcc.bnl.gov)
+# Single place to update campaign: change the variables block below.
+# These are passed to snakemake via --config, so no Snakefile edit needed.
+.dis_campaign_config:
+  variables:
+    DIS_CAMPAIGN: "26.05.0"
+    DIS_BEAM: "9x130"
+    DIS_Q2_RANGE: "q2_10to100"
+    DIS_NFILES: "5"
+    DIS_SNAKEMAKE_CONFIG: "dis_campaign=${DIS_CAMPAIGN} dis_beam=${DIS_BEAM} dis_q2_range=${DIS_Q2_RANGE} dis_nfiles=${DIS_NFILES}"
+
+sim:tracking_performances_dis:campaign:
+  extends:
+    - .det_benchmark
+    - .dis_campaign_config
+  stage: simulate
+  timeout: 2 hours
+  script:
+    - snakemake $SNAKEMAKE_FLAGS --cores $MAX_CORES_PER_JOB --config $DIS_SNAKEMAKE_CONFIG trk_dis_campaign vtx_dis_campaign
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+
+bench:tracking_performances_dis:campaign:
+  extends:
+    - .det_benchmark
+    - .dis_campaign_config
+  stage: benchmarks
+  needs:
+    - ["sim:tracking_performances_dis:campaign"]
+  script:
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 --config $DIS_SNAKEMAKE_CONFIG trk_dis_campaign vtx_dis_campaign
+    - find results/tracking_performances_dis/campaign_${DIS_CAMPAIGN}/ -mindepth 4 -maxdepth 4 -type d ! -name "combined*" | xargs rm -rfv
+    - find results/vertexing_performances_dis/campaign_${DIS_CAMPAIGN}/ -mindepth 4 -maxdepth 4 -type d ! -name "combined*" | xargs rm -rfv
+
+collect_results:tracking_performances_dis:campaign:
+  extends:
+    - .det_benchmark
+    - .dis_campaign_config
+  stage: collect
+  needs:
+    - "bench:tracking_performances_dis:campaign"
+  script:
+    - mv results{,_save}/
+    - snakemake $SNAKEMAKE_FLAGS --cores 1 --config $DIS_SNAKEMAKE_CONFIG --delete-all-output trk_dis_campaign vtx_dis_campaign
+    - mv results{_save,}/
+    - TRK_DIR="results/tracking_performances_dis/campaign_${DIS_CAMPAIGN}/epic_craterlake/${DIS_BEAM}/${DIS_Q2_RANGE}/combined_${DIS_NFILES}"
+    - VTX_DIR="results/vertexing_performances_dis/campaign_${DIS_CAMPAIGN}/epic_craterlake/${DIS_BEAM}/${DIS_Q2_RANGE}/combined_${DIS_NFILES}"
+    - gs -sDEVICE=pngalpha -dUseCropBox -r144 -o "${TRK_DIR}/tracking_performances_dis_%03d.png" "${TRK_DIR}/plots.pdf"
+    - gs -sDEVICE=pngalpha -dUseCropBox -r144 -o "${VTX_DIR}/vertexing_performances_dis_%03d.png" "${VTX_DIR}/plots.pdf"
+


### PR DESCRIPTION
- New Snakemake rules: dis_campaign_analysis, dis_campaign_sim_list (checkpoint), dis_campaign_combine, trk/vtx_dis_campaign_plots, and trk/vtx_dis_campaign invocation rules
- Campaign config via DIS_CAMPAIGN_CONFIG dict in Snakefile, overridable via snakemake --config; streams pre-reconstructed files directly from epicxrd1.sdcc.bnl.gov (BNL xrootd)
- CI jobs added: sim/bench/collect_results for tracking_performances_dis:campaign
- collect_results:tracking_performances_dis:campaign added to deploy_results needs in .gitlab-ci.yml

