### PR TITLE
benchmarks/rich: fix compatibility with edm4hep-1.0, podio-1.7

### DIFF
--- a/benchmarks/rich/run_benchmark.rb
+++ b/benchmarks/rich/run_benchmark.rb
@@ -202,7 +202,7 @@ output_collections = [
   "DRICHAerogelIrtCherenkovParticleID",
   "DRICHGasIrtCherenkovParticleID",
   "DRICHMergedIrtCherenkovParticleID",
-  "ReconstructedChargedParticleAssociationsWithDRICHPID",
+  "ReconstructedChargedParticleAssociations",
 ]
 recon_cmd = [
   'eicrecon',

--- a/benchmarks/rich/src/ReconstructedParticleAnalysis.cc
+++ b/benchmarks/rich/src/ReconstructedParticleAnalysis.cc
@@ -30,7 +30,7 @@ namespace benchmarks {
       const edm4eic::MCRecoParticleAssociationCollection& in_assocs
       )
   {
-    if(!in_assocs.isValid()) { m_log->error("invalid input collection 'in_assocs'"); return; }
+    if(!in_assocs.hasID()) { m_log->error("invalid input collection 'in_assocs'"); return; }
 
     // loop over input associations
     for(const auto& assoc : in_assocs) {

--- a/benchmarks/rich/src/benchmark.cc
+++ b/benchmarks/rich/src/benchmark.cc
@@ -31,10 +31,9 @@ std::shared_ptr<spdlog::logger> m_log;
 // get a collection by name; logs an error and returns an empty collection if not available
 template<class C>
 const C& GetCollection(podio::Frame& frame, std::string name) {
-#if podio_VERSION >= PODIO_VERSION(0, 99, 0)
   // Since podio 1.7, Frame::get<C>() throws std::runtime_error if the
   // collection is absent or has a mismatched type (older versions returned a
-  // static empty collection). Use try-catch to handle both behaviours.
+  // static empty collection). Try-catch handles both behaviours correctly.
   try {
     return frame.get<C>(name);
   } catch(const std::exception& e) {
@@ -42,12 +41,6 @@ const C& GetCollection(podio::Frame& frame, std::string name) {
     static C empty_coll;
     return empty_coll;
   }
-#else
-  const auto& coll = frame.get<C>(name);
-  if(!coll.isValid())
-    m_log->error("invalid collection '{}'", name);
-  return coll;
-#endif
 }
 
 // -------------------------------------------------------------

--- a/benchmarks/rich/src/benchmark.cc
+++ b/benchmarks/rich/src/benchmark.cc
@@ -30,7 +30,7 @@ std::shared_ptr<spdlog::logger> m_log;
 
 // get a collection by name; logs an error and returns an empty collection if not available
 template<class C>
-const C& GetCollection(podio::Frame& frame, std::string name) {
+const C& GetCollection(podio::Frame& frame, const std::string& name) {
   // Since podio 1.7, Frame::get<C>() throws std::runtime_error if the
   // collection is absent or has a mismatched type (older versions returned a
   // static empty collection). Try-catch handles both behaviours correctly.

--- a/benchmarks/rich/src/benchmark.cc
+++ b/benchmarks/rich/src/benchmark.cc
@@ -32,9 +32,9 @@ std::shared_ptr<spdlog::logger> m_log;
 template<class C>
 const C& GetCollection(podio::Frame& frame, std::string name) {
 #if podio_VERSION >= PODIO_VERSION(0, 99, 0)
-  // In podio >= 0.99.0, Frame::get<C>() throws std::runtime_error if the
-  // collection is absent or has a mismatched type, rather than returning an
-  // invalid collection.
+  // Since podio 1.7, Frame::get<C>() throws std::runtime_error if the
+  // collection is absent or has a mismatched type (older versions returned a
+  // static empty collection). Use try-catch to handle both behaviours.
   try {
     return frame.get<C>(name);
   } catch(const std::exception& e) {

--- a/benchmarks/rich/src/benchmark.cc
+++ b/benchmarks/rich/src/benchmark.cc
@@ -28,13 +28,26 @@ using namespace benchmarks;
 // main logger
 std::shared_ptr<spdlog::logger> m_log;
 
-// get a collection, and check its validity
+// get a collection by name; logs an error and returns an empty collection if not available
 template<class C>
 const C& GetCollection(podio::Frame& frame, std::string name) {
+#if podio_VERSION >= PODIO_VERSION(0, 99, 0)
+  // In podio >= 0.99.0, Frame::get<C>() throws std::runtime_error if the
+  // collection is absent or has a mismatched type, rather than returning an
+  // invalid collection.
+  try {
+    return frame.get<C>(name);
+  } catch(const std::exception& e) {
+    m_log->error("cannot get collection '{}': {}", name, e.what());
+    static C empty_coll;
+    return empty_coll;
+  }
+#else
   const auto& coll = frame.get<C>(name);
   if(!coll.isValid())
     m_log->error("invalid collection '{}'", name);
   return coll;
+#endif
 }
 
 // -------------------------------------------------------------


### PR DESCRIPTION
## Problem

The RICH benchmark failed when upgrading to edm4hep-1.0, podio-1.7, algorithms-1.3.0, k4fwcore-1.5 (CI job [#7877888](https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7877888)):

```
terminate called after throwing an instance of 'std::runtime_error'
what(): Cannot retrieve collection ReconstructedChargedParticleAssociations of type edm4eic::MCRecoParticleAssociationCollection
```

## Root Cause

Three interacting issues:

1. **Stale collection name**: `run_benchmark.rb` requested `ReconstructedChargedParticleAssociationsWithDRICHPID` in `output_collections`, but this collection **no longer exists** in EICrecon. Since JANA2's podio output writes only the explicitly listed collections, `ReconstructedChargedParticleAssociations` was absent from the rec file.

2. **podio 1.7 API change**: `Frame::get<C>(name)` now throws `std::runtime_error` when a collection is absent or has a type mismatch (podio 1.6 and earlier returned a static empty collection instead). The old `isValid()` guard was therefore never reached — the exception propagated uncaught.

3. **Deprecated API**: `isValid()` on collections is deprecated in the edm4eic-generated headers in favour of `hasID()`.

Note: before the podio 1.7 upgrade the stale collection name caused the `ReconstructedParticle` analysis to silently produce empty results rather than crash, since `Frame::get<C>()` returned an invalid collection without throwing.

## Fix

- **`run_benchmark.rb`**: Replace non-existent `ReconstructedChargedParticleAssociationsWithDRICHPID` with `ReconstructedChargedParticleAssociations` (the correct current EICrecon output collection name).
- **`src/benchmark.cc`**: Wrap `frame.get<C>()` in a try-catch; return an empty collection on error so callers can continue gracefully. The try-catch is harmless for older podio versions where `get<C>()` does not throw.
- **`src/ReconstructedParticleAnalysis.cc`**: Replace deprecated `isValid()` with `hasID()`.