### PR TITLE
calo_pid: avoid passing Awkward arrays to scikit

### DIFF
--- a/benchmarks/calo_pid/calo_pid.org
+++ b/benchmarks/calo_pid/calo_pid.org
@@ -276,8 +276,7 @@ for energy_bin_ix, (energy_bin_low, energy_bin_high) in enumerate(zip(energy_bin
    plt.clf()
 
    fpr, tpr, _ = roc_curve(
-      eval_y[cond][:,1],
-      #eval_x[cond][:,1],
+      eval_y[cond][:,1].to_numpy(),
       clf.predict_proba(eval_x[cond].to_numpy())[:,1],
    )
    cond = fpr != 0 # avoid infinite rejection (region of large uncertainty)


### PR DESCRIPTION
```
  File "/builds/EIC/benchmarks/detector_benchmarks/benchmarks/calo_pid/calo_pid.org2py.py", line 187, in <module>
    fpr, tpr, _ = roc_curve(
                  ~~~~~~~~~^
       eval_y[cond][:,1],
       ^^^^^^^^^^^^^^^^^^
       #eval_x[cond][:,1],
       ^^^^^^^^^^^^^^^^^^^
       clf.predict_proba(eval_x[cond].to_numpy())[:,1],
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/opt/local/lib/python3.13/site-packages/sklearn/utils/_param_validation.py", line 218, in wrapper
    return func(*args, **kwargs)
  File "/opt/local/lib/python3.13/site-packages/sklearn/metrics/_ranking.py", line 1319, in roc_curve
    _, fps, _, tps, thresholds = confusion_matrix_at_thresholds(
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/opt/local/lib/python3.13/site-packages/sklearn/utils/validation.py", line 80, in inner_f
    return f(*args, **kwargs)
  File "/opt/local/lib/python3.13/site-packages/sklearn/utils/_param_validation.py", line 191, in wrapper
    return func(*args, **kwargs)
  File "/opt/local/lib/python3.13/site-packages/sklearn/metrics/_ranking.py", line 1012, in confusion_matrix_at_thresholds
    pos_label = _check_pos_label_consistency(pos_label, y_true)
  File "/opt/local/lib/python3.13/site-packages/sklearn/utils/validation.py", line 2711, in _check_pos_label_consistency
    (_is_numpy_namespace(xp) and classes.dtype.kind in "OUS")
                                 ^^^^^^^^^^^^^
  File "/opt/local/lib/python3.13/site-packages/awkward/highlevel.py", line 1300, in __getattr__
    raise AttributeError(f"no field named {where!r}")
```