### PR TITLE
add part_handler_compat_check to check that old geometries still work with TC particle handler

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,6 +160,7 @@ include:
   - local: 'benchmarks/nhcal_sampling_fraction/config.yml'
   - local: 'benchmarks/nhcal_dimuon_photoproduction/config.yml'
   - local: 'benchmarks/nhcal_pion_rejection/config.yml'
+  - local: 'benchmarks/part_handler_compat_check/config.yml'
   
 deploy_results:
   allow_failure: true
@@ -201,6 +202,7 @@ deploy_results:
     - "collect_results:nhcal_sampling_fraction"
     - "collect_results:nhcal_dimuon_photoproduction"
     - "collect_results:nhcal_pion_rejection"
+    - "collect_results:part_handler_compat_check"
   script:
     - snakemake $SNAKEMAKE_FLAGS --cores 1 results/metadata.json
     - find results -print | sort | tee summary.txt

--- a/benchmarks/part_handler_compat_check/config.yml
+++ b/benchmarks/part_handler_compat_check/config.yml
@@ -1,0 +1,64 @@
+sim:part_handler_compat_check:
+  extends: .det_benchmark
+  stage: simulate
+  before_script:
+    - source .local/bin/env.sh
+    - git clone --depth 1 --branch 26.03.0 https://github.com/eic/epic.git epic
+    - cmake -S epic -B epic-build -DCMAKE_INSTALL_PREFIX="${PWD}/epic-install"
+    - cmake --build epic-build --target install -- -j$(nproc)
+    - source "${PWD}/epic-install/bin/thisepic.sh"
+    - ln -s "${LOCAL_DATA_PATH}/sim_output" sim_output
+    - ln -s "${LOCAL_DATA_PATH}/EPIC" EPIC
+  script:
+    # This should succeed: explicit Geant4TCUserParticleHandler avoids the tracking volume requirement
+    - >-
+      npsim
+      --part.userParticleHandler Geant4TCUserParticleHandler
+      --compactFile $DETECTOR_PATH/$DETECTOR_CONFIG.xml
+      --numberOfEvents 10
+      --enableGun
+      --gun.thetaMin 'pi/2'
+      --gun.thetaMax 'pi/2'
+      --gun.distribution uniform
+      --gun.phiMin '0*deg'
+      --gun.phiMax '0*deg'
+      --gun.energy '1*GeV'
+      --gun.particle 'e-'
+      --outputFile sim.edm4hep.root
+    # This should fail with a specific error about missing tracking_volume
+    - |
+      set +e
+      npsim \
+        --compactFile $DETECTOR_PATH/$DETECTOR_CONFIG.xml \
+        --numberOfEvents 10 \
+        --enableGun \
+        --gun.thetaMin 'pi/2' \
+        --gun.thetaMax 'pi/2' \
+        --gun.distribution uniform \
+        --gun.phiMin '0*deg' \
+        --gun.phiMax '0*deg' \
+        --gun.energy '1*GeV' \
+        --gun.particle 'e-' \
+        --outputFile sim_should_fail.edm4hep.root \
+        2>&1 | tee npsim_fail.log
+      EXIT_CODE=${PIPESTATUS[0]}
+      set -e
+      echo "npsim exit code: $EXIT_CODE"
+      if [[ "$EXIT_CODE" -eq "0" ]]; then
+        echo "ERROR: npsim should have failed but succeeded"
+        exit 1
+      fi
+      if ! grep -q "Geant4TVEicParticleHandler requested but no tracking_volume defined" npsim_fail.log; then
+        echo "ERROR: npsim failed but not with the expected error message about tracking_volume"
+        cat npsim_fail.log
+        exit 1
+      fi
+      echo "OK: npsim failed with the expected error message"
+
+collect_results:part_handler_compat_check:
+  extends: .det_benchmark
+  stage: collect
+  needs:
+    - ["sim:part_handler_compat_check"]
+  script:
+    - echo "part_handler_compat_check passed"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This checks that old geometry can still be loaded with npsim, if user follows the suggested workaround.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
