### PR TITLE
fix: prefer root-config incdir/libdir until TROOT::GetSharedLibDir fixed

### DIFF
--- a/benchmarks/lowq2_reconstruction/Snakefile
+++ b/benchmarks/lowq2_reconstruction/Snakefile
@@ -19,8 +19,8 @@ rule filter_hepmc_for_training:
     shell:
         """
         # Ensure ROOT 6.40.00-02 finds ROOT.modulemap
-        export ROOT_INCLUDE_PATH="$(root-config --incdir)${ROOT_INCLUDE_PATH:+:$ROOT_INCLUDE_PATH}"
-        export LD_LIBRARY_PATH="$(root-config --libdir)${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        export ROOT_INCLUDE_PATH="$(root-config --incdir)${{ROOT_INCLUDE_PATH:+:$ROOT_INCLUDE_PATH}}"
+        export LD_LIBRARY_PATH="$(root-config --libdir)${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"
         python {input.script} --outFile {output} --inFile {params.events}
         """
 

--- a/benchmarks/lowq2_reconstruction/Snakefile
+++ b/benchmarks/lowq2_reconstruction/Snakefile
@@ -18,6 +18,9 @@ rule filter_hepmc_for_training:
     singularity: EIC_SINGULARITY_CONTAINER,
     shell:
         """
+        # Ensure ROOT 6.40.00-02 finds ROOT.modulemap
+        export ROOT_INCLUDE_PATH=$(root-config --incdir)
+        export LD_LIBRARY_PATH=$(root-config --libdir):$LD_LIBRARY_PATH
         python {input.script} --outFile {output} --inFile {params.events}
         """
 

--- a/benchmarks/lowq2_reconstruction/Snakefile
+++ b/benchmarks/lowq2_reconstruction/Snakefile
@@ -19,8 +19,8 @@ rule filter_hepmc_for_training:
     shell:
         """
         # Ensure ROOT 6.40.00-02 finds ROOT.modulemap
-        export ROOT_INCLUDE_PATH=$(root-config --incdir)
-        export LD_LIBRARY_PATH=$(root-config --libdir):$LD_LIBRARY_PATH
+        export ROOT_INCLUDE_PATH="$(root-config --incdir)${ROOT_INCLUDE_PATH:+:$ROOT_INCLUDE_PATH}"
+        export LD_LIBRARY_PATH="$(root-config --libdir)${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
         python {input.script} --outFile {output} --inFile {params.events}
         """
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
In the upgrade of ROOT to 6.40, we encounter `fatal error: module map file '../../include/root/ROOT.modulemap' not found`, e.g. in https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/8009886#L1102. This is attributed to the changes in how ROOT determines the location of the include dir when starting from the lib dir. ROOT fails to resolve this correctly when our libCore.so is a symlink, and when libCore.so does not have the same filename as the soversion-appended libCore.so.6.40 file. While fixes are in preparation, this is a workaround.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/8009886#L1102)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
