### PR TITLE
lowq2_reconstruction: preload ROOT libCore for filterHEPMC3

### DIFF
--- a/benchmarks/lowq2_reconstruction/Snakefile
+++ b/benchmarks/lowq2_reconstruction/Snakefile
@@ -21,6 +21,11 @@ rule filter_hepmc_for_training:
         # Ensure ROOT 6.40.00-02 finds ROOT.modulemap
         export ROOT_INCLUDE_PATH="$(root-config --incdir)${{ROOT_INCLUDE_PATH:+:$ROOT_INCLUDE_PATH}}"
         export LD_LIBRARY_PATH="$(root-config --libdir)${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"
+        # FIXME: Work around a ROOT upstream bug in progress; preloading libCore.so.6.40
+        # forces resolution to the non-patch-level soname so ROOT.modulemap is found correctly.
+        # With a single ROOT install in these containers, this should remain harmless after
+        # upgrades away from ROOT 6.40.
+        export LD_PRELOAD="${{LD_PRELOAD:+$LD_PRELOAD:}}/opt/local/lib/root/libCore.so.6.40"
         python {input.script} --outFile {output} --inFile {params.events}
         """
 


### PR DESCRIPTION
## Why
The `filterHEPMC3.py` step can fail to locate `ROOT.modulemap` when library resolution lands on a patch-level variant instead of the expected soname. This blocks stable Low-Q2 training event filtering in the container environment.

## What changed
In `benchmarks/lowq2_reconstruction/Snakefile`, the `filter_hepmc_for_training` shell block now preloads:

`LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}/opt/local/lib/root/libCore.so.6.40"`

This is added alongside the existing ROOT include/library path exports so resolution consistently targets the non-patch-level `.so` needed for correct modulemap discovery.

## Notes for reviewers
A `FIXME` comment flags this as a temporary workaround for an in-progress ROOT upstream bug. With a single ROOT installation in these containers, keeping this preload should be low risk even as we upgrade away from ROOT 6.40.